### PR TITLE
Escape SQL field names

### DIFF
--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -330,7 +330,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$where = $this->regex ? '' : " WHERE `$col`" . $wpdb->prepare( ' LIKE %s', '%' . self::esc_like( $old ) . '%' );
 		$primary_keys_sql = esc_sql( implode( ',', $primary_keys ) );
 		$col_sql = esc_sql( $col );
-		$rows = $wpdb->get_results( "SELECT {$primary_keys_sql} FROM `{$table}` {$where}" );
+		$rows = $wpdb->get_results( "SELECT `{$primary_keys_sql}` FROM `{$table}` {$where}" );
 		foreach ( $rows as $keys ) {
 			$where_sql = '';
 			foreach( (array) $keys as $k => $v ) {
@@ -339,7 +339,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 				}
 				$where_sql .= "{$k}='{$v}'";
 			}
-			$col_value = $wpdb->get_var( "SELECT {$col_sql} FROM `{$table}` WHERE {$where_sql}" );
+			$col_value = $wpdb->get_var( "SELECT `{$col_sql}` FROM `{$table}` WHERE {$where_sql}" );
 			if ( '' === $col_value )
 				continue;
 

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -328,9 +328,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$replacer = new \WP_CLI\SearchReplacer( $old, $new, $this->recurse_objects, $this->regex, $this->regex_flags );
 
 		$where = $this->regex ? '' : " WHERE `$col`" . $wpdb->prepare( ' LIKE %s', '%' . self::esc_like( $old ) . '%' );
-		$primary_keys_sql = esc_sql( implode( ',', $primary_keys ) );
+		$primary_keys_sql = '`' . esc_sql( implode( '`,`', $primary_keys ) ) . '`';
 		$col_sql = esc_sql( $col );
-		$rows = $wpdb->get_results( "SELECT `{$primary_keys_sql}` FROM `{$table}` {$where}" );
+		$rows = $wpdb->get_results( "SELECT {$primary_keys_sql} FROM `{$table}` {$where}" );
 		foreach ( $rows as $keys ) {
 			$where_sql = '';
 			foreach( (array) $keys as $k => $v ) {


### PR DESCRIPTION
as poorly written plugins use `key` as field name.

```sql
SELECT key FROM `wpge_akeeba_common`  WHERE `key` LIKE '%/var/www/org.hu/html%'
```