### PR TITLE
Add esc_sql_ident(), catering for reserved word column names.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 vendor/
 *.zip
 *.tar.gz
+*.swp


### PR DESCRIPTION
PR https://github.com/wp-cli/search-replace-command/pull/4

Adds `esc_sql_ident()` func to backtick column/table names and uses it throughout, though the only real fixes (excluding the unlikely case of backticks in column/table names) is in `php_handle_col()`, where primary keys weren't escaped, as mentioned in the original PR, and `esc_sql()`was used for `$col_sql`.

(A similar fix needs to be done for `db search`.)

Also adds note about the double escaping in the WP <= 3.9 part of `esc_like()` which I thought was wrong but turns out to be necessary.
