### PR TITLE
Suppress error on fopen export file, revert PR #16.

### DIFF
--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -153,15 +153,11 @@ Feature: Search / replace with file export
 
   Scenario: Search / replace export invalid file
     Given a WP install
-    And a suppress-error-log.php file:
-      """
-      <?php ini_set( 'error_log', null );
-      """
 
-    When I try `wp --require=suppress-error-log.php search-replace example.com example.net --export=foo/bar.sql`
+    When I try `wp search-replace example.com example.net --export=foo/bar.sql`
     Then STDERR should contain:
       """
-      Error: Unable to open "foo/bar.sql" for writing.
+      Error: Unable to open "foo/bar.sql" for writing:
       """
 
   Scenario: Search / replace specific table

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -153,9 +153,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 				$this->export_handle = STDOUT;
 				$this->verbose = false;
 			} else {
-				$this->export_handle = fopen( $assoc_args['export'], 'w' );
+				$this->export_handle = @fopen( $assoc_args['export'], 'w' );
 				if ( false === $this->export_handle ) {
-					WP_CLI::error( sprintf( 'Unable to open "%s" for writing.', $assoc_args['export'] ) );
+					$error = error_get_last();
+					WP_CLI::error( sprintf( 'Unable to open "%s" for writing: %s.', $assoc_args['export'], $error['message'] ) );
 				}
 			}
 			$export_insert_size = WP_CLI\Utils\get_flag_value( $assoc_args, 'export_insert_size', 50 );


### PR DESCRIPTION
PR https://github.com/wp-cli/search-replace-command/pull/16

Suppresses PHP Notice on `fopen()` export file and reverts https://github.com/wp-cli/search-replace-command/pull/16 which suppressed PHP Notices in the test - ie the proper fix.