### PR TITLE
Add `--regex-delimiter`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "prefer-stable": true,
     "autoload": {
         "psr-4": {
-            "": "src/",
-            "WP_CLI\\": "src/WP_CLI"
+            "": "src/"
         },
         "files": [
             "search-replace-command.php"

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -341,6 +341,20 @@ Feature: Do global search/replace
       http://BAXAMPLE.com
       """
 
+  Scenario: Search replace with a regex delimiter
+    Given a WP install
+
+    When I run `wp search-replace 'HTTP://EXAMPLE.COM' 'http://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='#'`
+    Then STDOUT should be a table containing rows:
+      | Table      | Column       | Replacements | Type       |
+      | wp_options | option_value | 0            | PHP        |
+
+    When I run `wp option get home`
+    Then STDOUT should be:
+      """
+      http://example.com
+      """
+
   Scenario: Formatting as count-only
     Given a WP install
     And I run `wp option set foo 'ALPHA.example.com'`

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -347,13 +347,20 @@ Feature: Do global search/replace
     When I run `wp search-replace 'HTTP://EXAMPLE.COM' 'http://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='#'`
     Then STDOUT should be a table containing rows:
       | Table      | Column       | Replacements | Type       |
-      | wp_options | option_value | 0            | PHP        |
+      | wp_options | option_value | 2            | PHP        |
 
     When I run `wp option get home`
     Then STDOUT should be:
       """
-      http://example.com
+      http://example.jp
       """
+
+    When I try `wp search-replace 'HTTP://EXAMPLE.COM' 'http://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='1'`
+    Then STDERR should be:
+      """
+      Error: Incorrect regex delimiter.
+      """
+    And the return code should be 1
 
   Scenario: Formatting as count-only
     Given a WP install

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -139,7 +139,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$this->verbose         =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'verbose' );
 		$this->regex           =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex' );
 		$this->regex_flags     =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-flags' );
-		$this->regex_delimiter =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex_delimiter', '/' );
+		$this->regex_delimiter =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', '/' );
 		$this->format          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
 
 		// http://php.net/manual/en/reference.pcre.pattern.modifiers.php

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -147,8 +147,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 			WP_CLI::error( "Incorrect PCRE modifiers." );
 		}
 
-		if ( '' === $this->regex_delimiter ) {
+		if ( empty( $this->regex_delimiter ) ) {
 			$this->regex_delimiter = '/';
+		} elseif( ! preg_match( '/^[^0-9\\s]{1}$/', $this->regex_delimiter ) ) {
+			WP_CLI::error( "Incorrect regex delimiter." );
 		}
 
 		$this->skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -8,6 +8,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	private $recurse_objects;
 	private $regex;
 	private $regex_flags;
+	private $regex_delimiter;
 	private $skip_columns;
 	private $include_columns;
 	private $format;
@@ -89,6 +90,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 * [--regex-flags=<regex-flags>]
 	 * : Pass PCRE modifiers to regex search-replace (e.g. 'i' for case-insensitivity).
 	 *
+	 * [--regex-delimiter=<regex-delimiter>]
+	 * : The delimiter to use for the regex. It must be escaped if it appears in the search string.
+	 *
 	 * [--format=<format>]
 	 * : Render output in a particular format.
 	 * ---
@@ -135,12 +139,16 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$this->verbose         =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'verbose' );
 		$this->regex           =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex' );
 		$this->regex_flags     =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-flags' );
+		$this->regex_delimiter =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex_delimiter', '/' );
 		$this->format          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
 
 		// http://php.net/manual/en/reference.pcre.pattern.modifiers.php
 		if ( $this->regex_flags && ! preg_match( '/^(?!.*(.).*\1)[imsxeADSUXJu]+$/', $this->regex_flags ) ) {
 			WP_CLI::error( "Incorrect PCRE modifiers." );
-			exit;
+		}
+
+		if ( '' === $this->regex_delimiter ) {
+			$this->regex_delimiter = '/';
 		}
 
 		$this->skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
@@ -291,7 +299,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 			'chunk_size' => $chunk_size
 		);
 
-		$replacer = new \WP_CLI\SearchReplacer( $old, $new, $this->recurse_objects, $this->regex, $this->regex_flags );
+		$replacer = new \WP_CLI\SearchReplacer( $old, $new, $this->recurse_objects, $this->regex, $this->regex_flags, $this->regex_delimiter );
 		$col_counts = array_fill_keys( $all_columns, 0 );
 		if ( $this->verbose && 'table' === $this->format ) {
 			$this->start_time = microtime( true );
@@ -356,7 +364,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		global $wpdb;
 
 		$count = 0;
-		$replacer = new \WP_CLI\SearchReplacer( $old, $new, $this->recurse_objects, $this->regex, $this->regex_flags );
+		$replacer = new \WP_CLI\SearchReplacer( $old, $new, $this->recurse_objects, $this->regex, $this->regex_flags, $this->regex_delimiter );
 
 		$table_sql = self::esc_sql_ident( $table );
 		$col_sql = self::esc_sql_ident( $col );

--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -13,12 +13,13 @@ class SearchReplacer {
 	 * @param string  $to              What we want it to be replaced with.
 	 * @param bool    $recurse_objects Should objects be recursively replaced?
 	 */
-	function __construct( $from, $to, $recurse_objects = false, $regex = false, $regex_flags = '' ) {
+	function __construct( $from, $to, $recurse_objects = false, $regex = false, $regex_flags = '', $regex_delimiter = '/' ) {
 		$this->from = $from;
 		$this->to = $to;
 		$this->recurse_objects = $recurse_objects;
 		$this->regex = $regex;
 		$this->regex_flags = $regex_flags;
+		$this->regex_delimiter = $regex_delimiter;
 
 		// Get the XDebug nesting level. Will be zero (no limit) if no value is set
 		$this->max_recursion = intval( ini_get( 'xdebug.max_nesting_level' ) );
@@ -83,7 +84,7 @@ class SearchReplacer {
 
 			else if ( is_string( $data ) ) {
 				if ( $this->regex ) {
-					$data = preg_replace( "/$this->from/$this->regex_flags", $this->to, $data );
+					$data = preg_replace( "$this->regex_delimiter$this->from$this->regex_delimiter$this->regex_flags", $this->to, $data );
 				} else {
 					$data = str_replace( $this->from, $this->to, $data );
 				}


### PR DESCRIPTION
`wp db search` supports `--regex-delimiter`, so this command will be better to support it too.