### PR TITLE
Improve validation for `--regex-flags` and `--regex-delimiter` and add tests for them

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -355,6 +355,17 @@ Feature: Do global search/replace
       http://example.jp
       """
 
+    When I run `wp search-replace 'http://example.jp/' 'http://example.com/' wp_options --regex-delimiter='/'`
+    Then STDOUT should be a table containing rows:
+      | Table      | Column       | Replacements | Type       |
+      | wp_options | option_value | 2            | PHP        |
+
+    When I run `wp option get home`
+    Then STDOUT should be:
+      """
+      http://example.com
+      """
+
     When I try `wp search-replace 'HTTP://EXAMPLE.COM' 'http://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='1'`
     Then STDERR should be:
       """

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -174,6 +174,10 @@ Feature: Do global search/replace
   Scenario: Regex search/replace with a incorrect `--regex-flags`
     Given a WP install
     When I try `wp search-replace '(Hello)\s(world)' '$2, $1' --regex --regex-flags='kppr'`
+    Then STDERR should be:
+      """
+      Error: The regex '/(Hello)\s(world)/kppr' fails.
+      """
     And the return code should be 1
 
   Scenario: Search and replace within theme mods
@@ -369,7 +373,7 @@ Feature: Do global search/replace
     When I try `wp search-replace 'HTTP://EXAMPLE.COM' 'http://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='1'`
     Then STDERR should be:
       """
-      Error: Incorrect regex delimiter.
+      Error: The regex '1HTTP://EXAMPLE.COM1i' fails.
       """
     And the return code should be 1
 

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -174,9 +174,13 @@ Feature: Do global search/replace
   Scenario: Regex search/replace with a incorrect `--regex-flags`
     Given a WP install
     When I try `wp search-replace '(Hello)\s(world)' '$2, $1' --regex --regex-flags='kppr'`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
-      Error: The regex '/(Hello)\s(world)/kppr' fails.
+      (Hello)\s(world)
+      """
+    And STDERR should contain:
+      """
+      kppr
       """
     And the return code should be 1
 

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -153,8 +153,6 @@ class Search_Replace_Command extends WP_CLI_Command {
 			WP_CLI::error( "Incorrect regex delimiter." );
 		}
 
-		$this->regex = str_replace( $this->regex_delimiter, "\\" . $this->regex_delimiter, $this->regex );
-
 		$this->skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
 		$this->include_columns = array_filter( explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'include-columns' ) ) );
 

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -91,7 +91,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 * : Pass PCRE modifiers to regex search-replace (e.g. 'i' for case-insensitivity).
 	 *
 	 * [--regex-delimiter=<regex-delimiter>]
-	 * : The delimiter to use for the regex. It must be escaped if it appears in the search string.
+	 * : The delimiter to use for the regex. It must be escaped if it appears in the search string. The default value is the result of `chr(1)`.
 	 *
 	 * [--format=<format>]
 	 * : Render output in a particular format.

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -143,6 +143,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$this->format          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
 
 		if ( ! empty( $this->regex ) ) {
+			if ( '' === $this->regex_delimiter ) {
+				$this->regex_delimiter = chr( 1 );
+			}
 			$search_regex = $this->regex_delimiter;
 			$search_regex .= $old;
 			$search_regex .= $this->regex_delimiter;

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -139,7 +139,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$this->verbose         =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'verbose' );
 		$this->regex           =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex' );
 		$this->regex_flags     =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-flags' );
-		$this->regex_delimiter =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', '/' );
+		$this->regex_delimiter =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', chr( 1 ) );
 		$this->format          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
 
 		if ( ! empty( $this->regex ) ) {

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -153,6 +153,8 @@ class Search_Replace_Command extends WP_CLI_Command {
 			WP_CLI::error( "Incorrect regex delimiter." );
 		}
 
+		$this->regex = str_replace( $this->regex_delimiter, "\\" . $this->regex_delimiter, $this->regex );
+
 		$this->skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
 		$this->include_columns = array_filter( explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'include-columns' ) ) );
 

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -142,14 +142,6 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$this->regex_delimiter =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', '/' );
 		$this->format          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
 
-		$this->skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
-		$this->include_columns = array_filter( explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'include-columns' ) ) );
-
-		if ( $old === $new && ! $this->regex ) {
-			WP_CLI::warning( "Replacement value '{$old}' is identical to search value '{$new}'. Skipping operation." );
-			exit;
-		}
-
 		if ( ! empty( $this->regex ) ) {
 			$search_regex = $this->regex_delimiter;
 			$search_regex .= $old;
@@ -158,6 +150,14 @@ class Search_Replace_Command extends WP_CLI_Command {
 			if ( false === @preg_match( $search_regex, '' ) ) {
 				\WP_CLI::error( "The regex '$search_regex' fails." );
 			}
+		}
+
+		$this->skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
+		$this->include_columns = array_filter( explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'include-columns' ) ) );
+
+		if ( $old === $new && ! $this->regex ) {
+			WP_CLI::warning( "Replacement value '{$old}' is identical to search value '{$new}'. Skipping operation." );
+			exit;
 		}
 
 		if ( null !== ( $export = \WP_CLI\Utils\get_flag_value( $assoc_args, 'export' ) ) ) {

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -142,17 +142,6 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$this->regex_delimiter =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex-delimiter', '/' );
 		$this->format          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' );
 
-		// http://php.net/manual/en/reference.pcre.pattern.modifiers.php
-		if ( $this->regex_flags && ! preg_match( '/^(?!.*(.).*\1)[imsxeADSUXJu]+$/', $this->regex_flags ) ) {
-			WP_CLI::error( "Incorrect PCRE modifiers." );
-		}
-
-		if ( empty( $this->regex_delimiter ) ) {
-			$this->regex_delimiter = '/';
-		} elseif( ! preg_match( '/^[^0-9\\s]{1}$/', $this->regex_delimiter ) ) {
-			WP_CLI::error( "Incorrect regex delimiter." );
-		}
-
 		$this->skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
 		$this->include_columns = array_filter( explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'include-columns' ) ) );
 

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -150,6 +150,16 @@ class Search_Replace_Command extends WP_CLI_Command {
 			exit;
 		}
 
+		if ( ! empty( $this->regex ) ) {
+			$search_regex = $this->regex_delimiter;
+			$search_regex .= $old;
+			$search_regex .= $this->regex_delimiter;
+			$search_regex .= $this->regex_flags;
+			if ( false === @preg_match( $search_regex, '' ) ) {
+				\WP_CLI::error( "The regex '$search_regex' fails." );
+			}
+		}
+
 		if ( null !== ( $export = \WP_CLI\Utils\get_flag_value( $assoc_args, 'export' ) ) ) {
 			if ( $this->dry_run ) {
 				WP_CLI::error( 'You cannot supply --dry-run and --export at the same time.' );

--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -84,7 +84,14 @@ class SearchReplacer {
 
 			else if ( is_string( $data ) ) {
 				if ( $this->regex ) {
-					$data = preg_replace( "$this->regex_delimiter$this->from$this->regex_delimiter$this->regex_flags", $this->to, $data );
+					$search_regex = $this->regex_delimiter;
+					$search_regex .= $this->from;
+					$search_regex .= $this->regex_delimiter;
+					$search_regex .= $this->regex_flags;
+					if ( false === @preg_match( $search_regex, '' ) ) {
+						\WP_CLI::error( "The regex '$search_regex' fails." );
+					}
+					$data = preg_replace( $search_regex, $this->to, $data );
 				} else {
 					$data = str_replace( $this->from, $this->to, $data );
 				}

--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -88,9 +88,6 @@ class SearchReplacer {
 					$search_regex .= $this->from;
 					$search_regex .= $this->regex_delimiter;
 					$search_regex .= $this->regex_flags;
-					if ( false === @preg_match( $search_regex, '' ) ) {
-						\WP_CLI::error( "The regex '$search_regex' fails." );
-					}
 					$data = preg_replace( $search_regex, $this->to, $data );
 				} else {
 					$data = str_replace( $this->from, $this->to, $data );


### PR DESCRIPTION
If regex is `/`, regex will be escaped like following.

```
http:\/\/example.com
```