### PR TITLE
Make dry run SQL LIKE query case sensitive.

### DIFF
--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -176,7 +176,7 @@ Feature: Search / replace with file export
       """
     And STDOUT should contain:
       """
-      Success: Made 1 replacements and exported to wordpress.sql.
+      Success: Made 1 replacement and exported to wordpress.sql.
       """
 
     When I run `wp db import wordpress.sql`

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -585,3 +585,36 @@ Feature: Do global search/replace
       """
       Warning: No primary keys for table 'no_key'.
       """
+
+  Scenario: Search / replace is case sensitive
+    Given a WP install
+    When I run `wp post create --post_title='Case Sensitive' --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace sensitive insensitive`
+    Then STDOUT should contain:
+      """
+      Success: Made 0 replacements.
+      """
+    And STDERR should be empty
+
+    When I run `wp search-replace sensitive insensitive --dry-run`
+    Then STDOUT should contain:
+      """
+      Success: 0 replacements to be made.
+      """
+    And STDERR should be empty
+
+    When I run `wp search-replace Sensitive insensitive --dry-run`
+    Then STDOUT should contain:
+      """
+      Success: 1 replacement to be made.
+      """
+    And STDERR should be empty
+
+    When I run `wp search-replace Sensitive insensitive`
+    Then STDOUT should contain:
+      """
+      Success: Made 1 replacement.
+      """
+    And STDERR should be empty

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -297,9 +297,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 		if ( ! $this->dry_run ) {
 			if ( ! empty( $assoc_args['export'] ) ) {
-				$success_message = "Made {$total} replacements and exported to {$assoc_args['export']}.";
+				$success_message = 1 === $total ? "Made 1 replacement and exported to {$assoc_args['export']}." : "Made {$total} replacements and exported to {$assoc_args['export']}.";
 			} else {
-				$success_message = "Made $total replacements.";
+				$success_message = 1 === $total ? "Made 1 replacement." : "Made $total replacements.";
 				if ( $total && 'Default' !== WP_CLI\Utils\wp_get_cache_type() ) {
 					$success_message .= ' Please remember to flush your persistent object cache with `wp cache flush`.';
 					if ( is_multisite() ) {
@@ -375,7 +375,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$table_sql = self::esc_sql_ident( $table );
 		$col_sql = self::esc_sql_ident( $col );
 		if ( $this->dry_run ) {
-			$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT($col_sql) FROM $table_sql WHERE $col_sql LIKE %s;", '%' . self::esc_like( $old ) . '%' ) );
+			$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT($col_sql) FROM $table_sql WHERE $col_sql LIKE BINARY %s;", '%' . self::esc_like( $old ) . '%' ) );
 		} else {
 			$count = $wpdb->query( $wpdb->prepare( "UPDATE $table_sql SET $col_sql = REPLACE($col_sql, %s, %s);", $old, $new ) );
 		}
@@ -395,7 +395,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 		$table_sql = self::esc_sql_ident( $table );
 		$col_sql = self::esc_sql_ident( $col );
-		$where = $this->regex ? '' : " WHERE $col_sql" . $wpdb->prepare( ' LIKE %s', '%' . self::esc_like( $old ) . '%' );
+		$where = $this->regex ? '' : " WHERE $col_sql" . $wpdb->prepare( ' LIKE BINARY %s', '%' . self::esc_like( $old ) . '%' );
 		$primary_keys_sql = implode( ',', self::esc_sql_ident( $primary_keys ) );
 		$rows = $wpdb->get_results( "SELECT {$primary_keys_sql} FROM {$table_sql} {$where}" );
 		foreach ( $rows as $keys ) {


### PR DESCRIPTION
The `LIKE` on the SQL query when doing a dry run needs to be case sensitive to report changes and count properly (as `REPLACE` is case sensitive).

So changes `LIKE` to cast search string to `BINARY`.

Also fixes plural of successful replacements message when only one replacement.
