### PR TITLE
Add `--skip-tables=<tables>` argument to exclude tables when performing search-replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contr
 ## Using
 
 ~~~
-wp search-replace <old> <new> [<table>...] [--dry-run] [--network] [--all-tables-with-prefix] [--all-tables] [--export[=<file>]] [--export_insert_size=<rows>] [--skip-columns=<columns>] [--include-columns=<columns>] [--precise] [--recurse-objects] [--verbose] [--regex] [--regex-flags=<regex-flags>] [--regex-delimiter=<regex-delimiter>] [--format=<format>] [--report] [--report-changed-only] [--log[=<file>]] [--before_context=<num>] [--after_context=<num>]
+wp search-replace <old> <new> [<table>...] [--dry-run] [--network] [--all-tables-with-prefix] [--all-tables] [--export[=<file>]] [--export_insert_size=<rows>] [--skip-tables=<tables>] [--skip-columns=<columns>] [--include-columns=<columns>] [--precise] [--recurse-objects] [--verbose] [--regex] [--regex-flags=<regex-flags>] [--regex-delimiter=<regex-delimiter>] [--format=<format>] [--report] [--report-changed-only] [--log[=<file>]] [--before_context=<num>] [--after_context=<num>]
 ~~~
 
 Searches through all rows in a selection of tables and replaces
@@ -60,6 +60,10 @@ change primary key values.
 		Define number of rows in single INSERT statement when doing SQL export.
 		You might want to change this depending on your database configuration
 		(e.g. if you need to do fewer queries). Default: 50
+
+	[--skip-tables=<tables>]
+		Do not perform the replacement on specific tables. Use commas to
+		specify multiple tables.
 
 	[--skip-columns=<columns>]
 		Do not perform the replacement on specific columns. Use commas to
@@ -135,9 +139,9 @@ change primary key values.
     # Bash script: Search/replace production to development url (multisite compatible)
     #!/bin/bash
     if $(wp --url=http://example.com core is-installed --network); then
-        wp search-replace --url=http://example.com 'http://example.com' 'http://example.dev' --recurse-objects --network --skip-columns=guid
+        wp search-replace --url=http://example.com 'http://example.com' 'http://example.dev' --recurse-objects --network --skip-columns=guid --skip-tables=wp_users
     else
-        wp search-replace 'http://example.com' 'http://example.dev' --recurse-objects --skip-columns=guid
+        wp search-replace 'http://example.com' 'http://example.dev' --recurse-objects --skip-columns=guid --skip-tables=wp_users
     fi
 
 ## Installing

--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -23,14 +23,13 @@ Feature: Search / replace with file export
     When I run `wp search-replace example.com example.net --skip-tables=wp_options --export`
     Then STDOUT should not contain:
       """
-      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
-    ('1', 'siteurl', 'http://example.com', 'yes'),
+      INSERT INTO `wp_options`
       """
 
     When I run `wp search-replace example.com example.net --skip-columns=option_value --export`
     Then STDOUT should contain:
       """
-      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
+      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES 
     ('1', 'siteurl', 'http://example.com', 'yes'),
       """
 
@@ -38,7 +37,7 @@ Feature: Search / replace with file export
     Then STDOUT should contain:
       """
       ('1', 'siteurl', 'http://example.com', 'yes');
-    INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
+    INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES 
       """
 
     When I run `wp search-replace foo bar --export | tail -n 1`

--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -20,7 +20,7 @@ Feature: Search / replace with file export
       http://example.com
       """
 
-    When I run `wp search-replace example.com example.net --skip-tables=wp_options --export
+    When I run `wp search-replace example.com example.net --skip-tables=wp_options --export`
     Then STDOUT should not contain:
       """
       INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES

--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -20,10 +20,17 @@ Feature: Search / replace with file export
       http://example.com
       """
 
+    When I run `wp search-replace example.com example.net --skip-tables=wp_options --export
+    Then STDOUT should not contain:
+      """
+      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
+  ('1', 'siteurl', 'http://example.com', 'yes'),
+      """
+
     When I run `wp search-replace example.com example.net --skip-columns=option_value --export`
     Then STDOUT should contain:
       """
-      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES 
+      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
     ('1', 'siteurl', 'http://example.com', 'yes'),
       """
 
@@ -31,9 +38,9 @@ Feature: Search / replace with file export
     Then STDOUT should contain:
       """
       ('1', 'siteurl', 'http://example.com', 'yes');
-    INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES 
+    INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
       """
-          
+
     When I run `wp search-replace foo bar --export | tail -n 1`
     Then STDOUT should not contain:
       """

--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -24,14 +24,14 @@ Feature: Search / replace with file export
     Then STDOUT should not contain:
       """
       INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
-('1', 'siteurl', 'http://example.com', 'yes'),
+    ('1', 'siteurl', 'http://example.com', 'yes'),
       """
 
     When I run `wp search-replace example.com example.net --skip-columns=option_value --export`
     Then STDOUT should contain:
       """
       INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
-('1', 'siteurl', 'http://example.com', 'yes'),
+    ('1', 'siteurl', 'http://example.com', 'yes'),
       """
 
     When I run `wp search-replace example.com example.net --skip-columns=option_value --export --export_insert_size=1`

--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -24,14 +24,14 @@ Feature: Search / replace with file export
     Then STDOUT should not contain:
       """
       INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
-  ('1', 'siteurl', 'http://example.com', 'yes'),
+('1', 'siteurl', 'http://example.com', 'yes'),
       """
 
     When I run `wp search-replace example.com example.net --skip-columns=option_value --export`
     Then STDOUT should contain:
       """
       INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
-    ('1', 'siteurl', 'http://example.com', 'yes'),
+('1', 'siteurl', 'http://example.com', 'yes'),
       """
 
     When I run `wp search-replace example.com example.net --skip-columns=option_value --export --export_insert_size=1`

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -9,6 +9,12 @@ Feature: Do global search/replace
       guid
       """
 
+    When I run `wp search-replace foo bar --skip-tables=wp_posts`
+    Then STDOUT should not contain:
+      """
+      wp_posts
+      """
+
     When I run `wp search-replace foo bar --skip-columns=guid`
     Then STDOUT should not contain:
       """

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -9,6 +9,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	private $regex;
 	private $regex_flags;
 	private $regex_delimiter;
+	private $skip_tables;
 	private $skip_columns;
 	private $include_columns;
 	private $format;
@@ -73,6 +74,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 * : Define number of rows in single INSERT statement when doing SQL export.
 	 * You might want to change this depending on your database configuration
 	 * (e.g. if you need to do fewer queries). Default: 50
+	 *
+	 * [--skip-tables=<tables>]
+	 * : Do not perform the replacement on specific tables. Use commas to
+	 * specify multiple tables.
 	 *
 	 * [--skip-columns=<columns>]
 	 * : Do not perform the replacement on specific columns. Use commas to
@@ -148,9 +153,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 *     # Bash script: Search/replace production to development url (multisite compatible)
 	 *     #!/bin/bash
 	 *     if $(wp --url=http://example.com core is-installed --network); then
-	 *         wp search-replace --url=http://example.com 'http://example.com' 'http://example.dev' --recurse-objects --network --skip-columns=guid
+	 *         wp search-replace --url=http://example.com 'http://example.com' 'http://example.dev' --recurse-objects --network --skip-columns=guid --skip-tables=wp_users
 	 *     else
-	 *         wp search-replace 'http://example.com' 'http://example.dev' --recurse-objects --skip-columns=guid
+	 *         wp search-replace 'http://example.com' 'http://example.dev' --recurse-objects --skip-columns=guid --skip-tables=wp_users
 	 *     fi
 	 */
 	public function __invoke( $args, $assoc_args ) {
@@ -195,6 +200,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		}
 
 		$this->skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
+		$this->skip_tables = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-tables' ) );
 		$this->include_columns = array_filter( explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'include-columns' ) ) );
 
 		if ( $old === $new && ! $this->regex ) {
@@ -270,6 +276,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 		// Get table names based on leftover $args or supplied $assoc_args
 		$tables = \WP_CLI\Utils\wp_get_table_names( $args, $assoc_args );
 		foreach ( $tables as $table ) {
+
+			if ( in_array( $table, $this->skip_tables ) ) {
+				continue;
+			}
 
 			$table_sql = self::esc_sql_ident( $table );
 

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -275,6 +275,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 		// Get table names based on leftover $args or supplied $assoc_args
 		$tables = \WP_CLI\Utils\wp_get_table_names( $args, $assoc_args );
+
+		// Removes from $tables tables provided by skip-tables argument
+		$tables = array_diff( $tables, $this->skip_tables );
+
 		foreach ( $tables as $table ) {
 
 			if ( in_array( $table, $this->skip_tables ) ) {


### PR DESCRIPTION
### Issue #31 
- Implemented a method to exclude tables by adding a new argument `--skip-tables`