### PR TITLE
Convert search-replace subcommand help summaries to use third-person singular verbs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 wp-cli/search-replace-command
 =============================
 
-Search/replace strings in the database.
+Searches/replaces strings in the database.
 
 [![Build Status](https://travis-ci.org/wp-cli/search-replace-command.svg?branch=master)](https://travis-ci.org/wp-cli/search-replace-command)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-cli/search-replace-command",
-    "description": "Search/replace strings in the database.",
+    "description": "Searches/replaces strings in the database.",
     "type": "wp-cli-package",
     "homepage": "https://github.com/wp-cli/search-replace-command",
     "support": {

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -24,7 +24,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	private $log_run_data = array();
 
 	/**
-	 * Search/replace strings in the database.
+	 * Searches/replaces strings in the database.
 	 *
 	 * Searches through all rows in a selection of tables and replaces
 	 * appearances of the first string with the second string.
@@ -815,7 +815,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	}
 
 	/*
-	 * Output the log strings.
+	 * Outputs the log strings.
 	 *
 	 * @param string $col Column being processed.
 	 * @param array $keys Associative array (or object) of primary key names and their values for the row being processed.


### PR DESCRIPTION
Per wp-cli/wp-cli#4542, this PR converts help docs for search-replace subcommands to use third-person singular verbs.