### PR TITLE
Do not show on report tables without index when using --report-change-only

### DIFF
--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -302,7 +302,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 			// since we'll be updating one row at a time,
 			// we need a primary key to identify the row
 			if ( empty( $primary_keys ) ) {
-				if ( $this->report ) {
+				if ( $this->report && ! $this->report_changed_only ) {
 					$report[] = array( $table, '', 'skipped', '' );
 				} else {
 					WP_CLI::warning( $all_columns ? "No primary keys for table '$table'." : "No such table '$table'." );


### PR DESCRIPTION
### Do not show on report tables without index when using --report-change-only

- Fix for The report prints a message when the table's primary key isn't found

Fixes #53 