### PR TITLE
Fix/report improvement

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -473,6 +473,7 @@ Feature: Do global search/replace
       """
     And STDERR should be empty
 
+  @suppress_report__only_changes
   Scenario: Suppress report or only report changes
     Given a WP install
 
@@ -570,6 +571,18 @@ Feature: Do global search/replace
       """
     And STDERR should be empty
 
+    When I run `wp search-replace nobaz1 baz6 --report-changed-only`
+    Then STDOUT should contain:
+      """
+      Success: Made 0 replacements.
+      """
+    And STDOUT should not contain:
+      """
+      Table	Column	Replacements	Type
+      """
+    And STDERR should be empty
+
+  @no_table__no_primary_key
   Scenario: Deal with non-existent table and table with no primary keys
     Given a WP install
 
@@ -607,6 +620,18 @@ Feature: Do global search/replace
     And STDOUT should end with a table containing rows:
     | Table  | Column | Replacements | Type |
     | no_key |        | skipped      |      |
+    And STDERR should be empty
+
+    And I run `wp search-replace foo bar no_key --report-changed-only`
+    Then STDOUT should contain:
+      """
+      Success: Made 0 replacements.
+      """
+    And STDOUT should not contain:
+      """
+      | Table  | Column | Replacements | Type |
+      | no_key |        | skipped      |      |
+      """
     And STDERR should be empty
 
     When I try `wp search-replace foo bar no_key --no-report`

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -369,7 +369,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 			return;
 		}
 
-		if ( $this->report ) {
+		if ( $this->report && ! empty( $report ) ) {
 			$table = new \cli\Table();
 			$table->setHeaders( array( 'Table', 'Column', 'Replacements', 'Type' ) );
 			$table->setRows( $report );

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -302,7 +302,12 @@ class Search_Replace_Command extends WP_CLI_Command {
 			// since we'll be updating one row at a time,
 			// we need a primary key to identify the row
 			if ( empty( $primary_keys ) ) {
-				if ( $this->report && ! $this->report_changed_only ) {
+
+				// wasn't updated, so skip to the next table
+				if ( $this->report_changed_only ) {
+					continue;
+				}
+				if ( $this->report ) {
 					$report[] = array( $table, '', 'skipped', '' );
 				} else {
 					WP_CLI::warning( $all_columns ? "No primary keys for table '$table'." : "No such table '$table'." );


### PR DESCRIPTION
1. when only reporting changes, if a table doesn't have primary keys, don't print any message.

2. if the content of the table is empty, don't print the headers.

3. added functional tests for ( using --report-changed-only )
- when made 0 replacements, report should be empty

- when a tables doesn't have a primary key, report should not contain the skipped table 

improvement from #55 