### PR TITLE
Allow for BIGINTs in esc_sql_value().

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -983,7 +983,6 @@ Feature: Do global search/replace
     Given a WP install
     And a test_db.sql file:
       """
-      DROP TABLE IF EXISTS `wp_123_test`;
       CREATE TABLE `wp_123_test` (
         `name` varchar(50),
         `value` varchar(5000),
@@ -991,19 +990,43 @@ Feature: Do global search/replace
         `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         PRIMARY KEY (`name`)
       ) ENGINE=InnoDB;
-      INSERT INTO `wp_123_test` VALUES ('test_val','off','2016-11-15 14:41:33','2016-11-15 21:41:33');
-      INSERT INTO `wp_123_test` VALUES ('123.','off','2016-11-15 14:41:33','2016-11-15 21:41:33');
-      INSERT INTO `wp_123_test` VALUES ('quote\'quote','off','2016-11-15 14:41:33','2016-11-15 21:41:33');
-      INSERT INTO `wp_123_test` VALUES ('0','off','2016-11-15 14:41:33','2016-11-15 21:41:33');
-      INSERT INTO `wp_123_test` VALUES ('','off','2016-11-15 14:41:33','2016-11-15 21:41:33');
-      """
+      INSERT INTO `wp_123_test` VALUES ('test_val','wp_123_test_value_X','2016-11-15 14:41:33','2016-11-15 21:41:33');
+      INSERT INTO `wp_123_test` VALUES ('123.','wp_123_test_value_X','2016-11-15 14:41:33','2016-11-15 21:41:33');
+      INSERT INTO `wp_123_test` VALUES ('quote\'quote','wp_123_test_value_X','2016-11-15 14:41:33','2016-11-15 21:41:33');
+      INSERT INTO `wp_123_test` VALUES ('0','wp_123_test_value_X','2016-11-15 14:41:33','2016-11-15 21:41:33');
+      INSERT INTO `wp_123_test` VALUES ('','wp_123_test_value_X','2016-11-15 14:41:33','2016-11-15 21:41:33');
+      INSERT INTO `wp_123_test` VALUES ('18446744073709551616','wp_123_test_value_X','2016-11-15 14:41:33','2016-11-15 21:41:33');
+      INSERT INTO `wp_123_test` VALUES ('-18446744073709551615','wp_123_test_value_X','2016-11-15 14:41:33','2016-11-15 21:41:33');
+      INSERT INTO `wp_123_test` VALUES ('123456789012345678801234567890','wp_123_test_value_X','2016-11-15 14:41:33','2016-11-15 21:41:33');
 
-    When I run `wp db query "SOURCE test_db.sql;"`
-    Then STDERR should be empty
+      CREATE TABLE `wp_123_test2` (`bigint_unsigned_key` BIGINT UNSIGNED NOT NULL, `value` VARCHAR(255), PRIMARY KEY (`bigint_unsigned_key`) );
+      INSERT INTO `wp_123_test2` VALUES ('18446744073709551615','wp_123_test2_value_X');
+
+      CREATE TABLE `wp_123_test3` (`bigint_signed_key` BIGINT SIGNED NOT NULL, `value` VARCHAR(255), PRIMARY KEY (`bigint_signed_key`) );
+      INSERT INTO `wp_123_test3` VALUES ('-9223372036854775808','wp_123_test3_value_X');
+      """
+    And I run `wp db query "SOURCE test_db.sql;"`
 
     When I run `wp search-replace --dry-run --regex 'mytestdomain.com\/' 'mytestdomain2.com/' --all-tables-with-prefix --skip-columns=guid,domain`
-    Then STDERR should be empty
-    And STDOUT should contain:
+    Then STDOUT should contain:
       """
       Success: 0 replacements to be made.
+      """
+
+    When I run `wp search-replace --dry-run --regex 'wp_123_test_value_X' 'wp_123_test_value_Y' --all-tables-with-prefix`
+    Then STDOUT should contain:
+      """
+      Success: 8 replacements to be made.
+      """
+
+    When I run `wp search-replace --dry-run --regex 'wp_123_test2_value_X' 'wp_123_test2_value_Y' --all-tables-with-prefix`
+    Then STDOUT should contain:
+      """
+      Success: 1 replacement to be made.
+      """
+
+    When I run `wp search-replace --dry-run --regex 'wp_123_test3_value_X' 'wp_123_test3_value_Y' --all-tables-with-prefix`
+    Then STDOUT should contain:
+      """
+      Success: 1 replacement to be made.
       """

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -658,7 +658,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	private static function esc_sql_value( $values ) {
 		$quote = function ( $v ) {
 			// Don't quote integer values to avoid MySQL's implicit type conversion.
-			if ( (string)(int) $v === (string) $v ) {
+			if ( preg_match( '/^[+-]?[0-9]{1,20}$/', $v ) ) { // MySQL BIGINT UNSIGNED max 18446744073709551615 (20 digits).
 				return esc_sql( $v );
 			}
 


### PR DESCRIPTION
Related https://github.com/wp-cli/search-replace-command/pull/59 and https://github.com/wp-cli/search-replace-command/issues/58

Allows for BIGINTs in `esc_sql_value()` which are > PHP_INT_MAX.