### PR TITLE
Remove "Site Not Found" message from multisite usage

### DIFF
--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -383,9 +383,6 @@ class Search_Replace_Command extends WP_CLI_Command {
 				$success_message = 1 === $total ? "Made 1 replacement." : "Made $total replacements.";
 				if ( $total && 'Default' !== WP_CLI\Utils\wp_get_cache_type() ) {
 					$success_message .= ' Please remember to flush your persistent object cache with `wp cache flush`.';
-					if ( is_multisite() ) {
-						$success_message .= ' If you see a "Site not found" error after replacing a domain, try flushing cache against the old domain (which may be the cached lookup value).';
-					}
 				}
 			}
 			WP_CLI::success( $success_message );


### PR DESCRIPTION
This quirk has since been addressed

Previously https://github.com/wp-cli/wp-cli/pull/4527