### PR TITLE
Handle PCRE errors gracefully

### DIFF
--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -2,6 +2,8 @@
 
 namespace WP_CLI;
 
+use Exception;
+
 class SearchReplacer {
 
 	private $from, $to;
@@ -102,7 +104,17 @@ class SearchReplacer {
 					$search_regex .= $this->from;
 					$search_regex .= $this->regex_delimiter;
 					$search_regex .= $this->regex_flags;
-					$data = preg_replace( $search_regex, $this->to, $data );
+
+					$result = preg_replace( $search_regex, $this->to, $data );
+					if ( null === $result || PREG_NO_ERROR !== preg_last_error() ) {
+						\WP_CLI::warning(
+							sprintf(
+								'The provided regular expression threw a PCRE error - %s',
+								$this->preg_error_message( $result )
+							)
+						);
+					}
+					$data = $result;
 				} else {
 					$data = str_replace( $this->from, $this->to, $data );
 				}
@@ -134,6 +146,22 @@ class SearchReplacer {
 	 */
 	public function clear_log_data() {
 		$this->log_data = array();
+	}
+
+	/**
+	 * Get the PCRE error constant name from an error value.
+	 *
+	 * @param  integer $error Error code.
+	 * @return string         Error constant name.
+	 */
+	private function preg_error_message( $error ) {
+		$constants = get_defined_constants( true );
+		if ( ! array_key_exists( 'pcre', $constants ) ) {
+			return '<unknown error>';
+		}
+
+		$names = array_flip( $constants['pcre'] );
+		return isset( $names[ $error ] ) ? $names[ $error ] : '<unknown error>';
 	}
 }
 


### PR DESCRIPTION
We leave the content untouched (instead of replacing with `null`) and issue a warning.

This is far from ideal, as it can potentially spam the screen full of warnings. However, a better mechanism will require a total refactor of the `SearchReplacer` class.

Fixes #65