### PR TITLE
Handle incomplete class (un)serialization gracefully

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -1030,3 +1030,25 @@ Feature: Do global search/replace
       """
       Success: 1 replacement to be made.
       """
+
+  # Regression test for https://github.com/wp-cli/search-replace-command/issues/68
+  Scenario: Incomplete classes are handled gracefully during (un)serialization
+
+    Given a WP install
+    And I run `wp option add cereal_isation 'a:1:{i:0;O:10:"CornFlakes":0:{}}'`
+
+    When I try `wp search-replace CornFlakes Smacks`
+    Then STDERR should contain:
+      """
+      Warning: Skipping an uninitialized class "CornFlakes", replacements might not be complete.
+      """
+    And STDOUT should contain:
+      """
+      Success: Made 0 replacements.
+      """
+
+    When I run `wp option get cereal_isation`
+    Then STDOUT should contain:
+      """
+      a:1:{i:0;O:10:"CornFlakes":0:{}}
+      """

--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -90,7 +90,7 @@ class SearchReplacer {
 				}
 			}
 
-			elseif ( $this->recurse_objects && is_object( $data ) ) {
+			elseif ( $this->recurse_objects && ( is_object( $data ) || $data instanceof \__PHP_Incomplete_Class ) ) {
 				if ( $data instanceof \__PHP_Incomplete_Class ) {
 					$array = new ArrayObject( $data );
 					\WP_CLI::warning(

--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -169,13 +169,19 @@ class SearchReplacer {
 	 * @return string         Error constant name.
 	 */
 	private function preg_error_message( $error ) {
-		$constants = get_defined_constants( true );
-		if ( ! array_key_exists( 'pcre', $constants ) ) {
-			return '<unknown error>';
+		static $error_names = null;
+
+		if ( null === $error_names ) {
+			$definitions    = get_defined_constants( true );
+			$pcre_constants = array_key_exists( 'pcre', $definitions )
+				? $definitions['pcre']
+				: array();
+			$error_names    = array_flip( $pcre_constants );
 		}
 
-		$names = array_flip( $constants['pcre'] );
-		return isset( $names[ $error ] ) ? $names[ $error ] : '<unknown error>';
+		return isset( $error_names[ $error ] )
+			? $error_names[ $error ]
+			: '<unknown error>';
 	}
 }
 

--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -2,6 +2,8 @@
 
 namespace WP_CLI;
 
+use ArrayObject;
+
 class SearchReplacer {
 
 	private $from, $to;
@@ -87,9 +89,22 @@ class SearchReplacer {
 				}
 			}
 
-			elseif ( $this->recurse_objects && is_object( $data ) ) {
-				foreach ( $data as $key => $value ) {
-					$data->$key = $this->_run( $value, false, $recursion_level + 1, $visited_data );
+			elseif ( $this->recurse_objects ) {
+				if ( $data instanceof \__PHP_Incomplete_Class ) {
+					$array = new ArrayObject( $data );
+					\WP_CLI::warning(
+						sprintf(
+							'Skipping an uninitialized class "%s", replacements might not be complete.',
+							$array['__PHP_Incomplete_Class_Name']
+						)
+					);
+					return $data;
+				}
+
+				if ( is_object( $data ) ) {
+					foreach ( $data as $key => $value ) {
+						$data->$key = $this->_run( $value, false, $recursion_level + 1, $visited_data );
+					}
 				}
 			}
 

--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -90,7 +90,7 @@ class SearchReplacer {
 				}
 			}
 
-			elseif ( $this->recurse_objects ) {
+			elseif ( $this->recurse_objects && is_object( $data ) ) {
 				if ( $data instanceof \__PHP_Incomplete_Class ) {
 					$array = new ArrayObject( $data );
 					\WP_CLI::warning(
@@ -99,10 +99,7 @@ class SearchReplacer {
 							$array['__PHP_Incomplete_Class_Name']
 						)
 					);
-					return $data;
-				}
-
-				if ( is_object( $data ) ) {
+				} else {
 					foreach ( $data as $key => $value ) {
 						$data->$key = $this->_run( $value, false, $recursion_level + 1, $visited_data );
 					}


### PR DESCRIPTION
When an unknown class is deserialized, we just throw a warning an avoid making a change, due to the lack of full knowledge of the class.

This also makes sure we don't throw a notice on PHP 7.2, which changed how `is_object()` deals with `_PHP_Incomplete_Class`.

Fixes #68