### PR TITLE
Corrects NULL export values.

### DIFF
--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -359,3 +359,17 @@ Feature: Search / replace with file export
       """
       'test-remove-placeholder-escape{'
       """
+
+  Scenario: NULLs exported as NULL and not null string
+    Given a WP install
+    And I run `wp db query "INSERT INTO wp_postmeta VALUES (9999, 9999, NULL, 'foo')"`
+
+    When I run `wp search-replace bar replaced wp_postmeta --export`
+    Then STDOUT should contain:
+      """
+     ('9999', '9999', NULL, 'foo')
+      """
+    And STDOUT should not contain:
+      """
+     ('9999', '9999', '', 'foo')
+      """

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -558,8 +558,18 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$export_insert_size = $this->export_insert_size;
 
 		foreach($rows as $row_fields) {
-			$sql .= '(' . join( ', ', array_fill( 0, count( $row_fields ), '%s' ) ) . ')';
-			$values = array_merge( $values, array_values( $row_fields ) );
+			$subs = array();
+			
+			foreach( $row_fields as $field_value ) {
+				if ( is_null($field_value) ) {
+					$subs[] = 'NULL';
+				} else {
+					$subs[] = '%s';
+					$values[] = $field_value;
+				}
+			}
+			
+			$sql .= '(' . join( ', ', $subs ) . ')';
 
 			// Add new insert statement if needed. Before this we close the previous with semicolon and write statement to sql-file.
 			// "Statement break" is needed:

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -561,7 +561,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 			$subs = array();
 			
 			foreach( $row_fields as $field_value ) {
-				if ( is_null($field_value) ) {
+				if ( null === $field_value ) {
 					$subs[] = 'NULL';
 				} else {
 					$subs[] = '%s';


### PR DESCRIPTION
The code that exports a search-replace command as SQL creates a prepared
statement where all columns values are assumed to be strings. Normally
this is fine as MySQL/MariaDB will do the conversion work at import.
However, in some cases, a column may allow nulls in a numeric field.
In this instance, the call to `prepare` will translate a null value into
null string. Importing will then fail as null string is not a numeric
value.

This patch replaces the original code that assumed strings for all bind
parameters. Each column value is iterated over and inspected. If the
value is not NULL, the value is added to the `$values` array and a bind
parameter, `%s` is added to a substituions array. If the value causes
`is_null` to return true, only 'NULL' is added to the substituions
array.

The code then evaluates as it did previously, with a `join` call
creating a string from the substitutions array and appending that string
to the larger SQL query.

This closes #82.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
