### PR TITLE
PHPCS: fix up the code base [5] - multi-line function calls

### DIFF
--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -721,9 +721,13 @@ class Search_Replace_Command extends WP_CLI_Command {
 	private function get_colors( $assoc_args, $colors ) {
 		$color_reset = WP_CLI::colorize( '%n' );
 
-		$color_codes = implode( '', array_map( function ( $v ) {
+		$color_code_callback = function ( $v ) {
 			return substr( $v, 1 );
-		}, array_keys( \cli\Colors::getColors() ) ) );
+		};
+
+		$color_codes = array_keys( \cli\Colors::getColors() );
+		$color_codes = array_map( $color_code_callback, $color_codes );
+		$color_codes = implode( '', $color_codes );
 
 		$color_codes_regex = '/^(?:%[' . $color_codes . '])*$/';
 


### PR DESCRIPTION
Multi-line function calls need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

With this mind, this function call with multi-line parameters which was already causing errors to be thrown by PHPCS, has been fixed by moving multi-line function call arguments out of the function call and defining these as a variable before passing it to the function call.

The multiple nested function calls have also been unnested.