### PR TITLE
PHPCS: fix up the code base [6] - multi-line function calls

### DIFF
--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -826,23 +826,33 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$i           = 0;
 		$diff        = 0;
 		$new_matches = array();
-		$new_data    = preg_replace_callback( $search_regex, function ( $matches ) use ( $old_matches, $new, $is_regex, &$new_matches, &$i, &$diff ) {
-			if ( $is_regex ) {
-				// Sub in any back references, "$1", "\2" etc, in the replacement string.
-				$new = preg_replace_callback( '/(?<!\\\\)(?:\\\\\\\\)*((?:\\\\|\\$)[0-9]{1,2}|\\${[0-9]{1,2}\\})/', function ( $m ) use ( $matches ) {
-					$idx = (int) str_replace( array( '\\', '$', '{', '}' ), '', $m[0] );
-					return isset( $matches[ $idx ] ) ? $matches[ $idx ] : '';
-				}, $new );
-				$new = str_replace( '\\\\', '\\', $new ); // Unescape any backslashed backslashes.
-			}
+		$new_data    = preg_replace_callback(
+			$search_regex,
+			function ( $matches ) use ( $old_matches, $new, $is_regex, &$new_matches, &$i, &$diff ) {
+				if ( $is_regex ) {
+					// Sub in any back references, "$1", "\2" etc, in the replacement string.
+					$new = preg_replace_callback(
+						'/(?<!\\\\)(?:\\\\\\\\)*((?:\\\\|\\$)[0-9]{1,2}|\\${[0-9]{1,2}\\})/',
+						function ( $m ) use ( $matches ) {
+							$idx = (int) str_replace( array( '\\', '$', '{', '}' ), '', $m[0] );
+							return isset( $matches[ $idx ] ) ? $matches[ $idx ] : '';
+						},
+						$new
+					);
+					$new = str_replace( '\\\\', '\\', $new ); // Unescape any backslashed backslashes.
+				}
 
-			$new_matches[0][ $i ][0] = $new;
-			$new_matches[0][ $i ][1] = $old_matches[0][ $i ][1] + $diff;
+				$new_matches[0][ $i ][0] = $new;
+				$new_matches[0][ $i ][1] = $old_matches[0][ $i ][1] + $diff;
 
-			$diff += strlen( $new ) - strlen( $old_matches[0][ $i ][0] );
-			$i++;
-			return $new;
-		}, $old_data, $this->regex_limit, $match_cnt );
+				$diff += strlen( $new ) - strlen( $old_matches[0][ $i ][0] );
+				$i++;
+				return $new;
+			},
+			$old_data,
+			$this->regex_limit,
+			$match_cnt
+		);
 
 		$old_bits        = array();
 		$new_bits        = array();


### PR DESCRIPTION
Fixes relate to the following rules:
* Each argument in a multiline function call should start on a new line.

Note: in the (near?) future, multi-line arguments in function calls will also be prohibited.
This will impact this code.

The choice for the future is:
* Either change the closures to full-blown methods.
* Declare each before their respective function call, assign them to a variable and pass the variable to the function call.

Note: this commit will be easiest to review by ignoring whitespace changes.