### PR TITLE
Swapped out the .dev Google TLD for the .test RFC protected domain in doc examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ change primary key values.
 **EXAMPLES**
 
     # Search and replace but skip one column
-    $ wp search-replace 'http://example.dev' 'http://example.com' --skip-columns=guid
+    $ wp search-replace 'http://example.test' 'http://example.com' --skip-columns=guid
 
     # Run search/replace operation but dont save in database
     $ wp search-replace 'foo' 'bar' wp_posts wp_postmeta wp_terms --dry-run
@@ -131,7 +131,7 @@ change primary key values.
     $ wp search-replace '\[foo id="([0-9]+)"' '[bar id="\1"' --regex --regex-flags='i'
 
     # Turn your production multisite database into a local dev database
-    $ wp search-replace --url=example.com example.com example.dev 'wp_*options' wp_blogs
+    $ wp search-replace --url=example.com example.com example.test 'wp_*options' wp_blogs
 
     # Search/replace to a SQL file without transforming the database
     $ wp search-replace foo bar --export=database.sql
@@ -139,9 +139,9 @@ change primary key values.
     # Bash script: Search/replace production to development url (multisite compatible)
     #!/bin/bash
     if $(wp --url=http://example.com core is-installed --network); then
-        wp search-replace --url=http://example.com 'http://example.com' 'http://example.dev' --recurse-objects --network --skip-columns=guid --skip-tables=wp_users
+        wp search-replace --url=http://example.com 'http://example.com' 'http://example.test' --recurse-objects --network --skip-columns=guid --skip-tables=wp_users
     else
-        wp search-replace 'http://example.com' 'http://example.dev' --recurse-objects --skip-columns=guid --skip-tables=wp_users
+        wp search-replace 'http://example.com' 'http://example.test' --recurse-objects --skip-columns=guid --skip-tables=wp_users
     fi
 
 ## Installing

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -139,7 +139,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # Search and replace but skip one column
-	 *     $ wp search-replace 'http://example.dev' 'http://example.com' --skip-columns=guid
+	 *     $ wp search-replace 'http://example.test' 'http://example.com' --skip-columns=guid
 	 *
 	 *     # Run search/replace operation but dont save in database
 	 *     $ wp search-replace 'foo' 'bar' wp_posts wp_postmeta wp_terms --dry-run
@@ -148,7 +148,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 *     $ wp search-replace '\[foo id="([0-9]+)"' '[bar id="\1"' --regex --regex-flags='i'
 	 *
 	 *     # Turn your production multisite database into a local dev database
-	 *     $ wp search-replace --url=example.com example.com example.dev 'wp_*options' wp_blogs
+	 *     $ wp search-replace --url=example.com example.com example.test 'wp_*options' wp_blogs
 	 *
 	 *     # Search/replace to a SQL file without transforming the database
 	 *     $ wp search-replace foo bar --export=database.sql
@@ -156,9 +156,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 *     # Bash script: Search/replace production to development url (multisite compatible)
 	 *     #!/bin/bash
 	 *     if $(wp --url=http://example.com core is-installed --network); then
-	 *         wp search-replace --url=http://example.com 'http://example.com' 'http://example.dev' --recurse-objects --network --skip-columns=guid --skip-tables=wp_users
+	 *         wp search-replace --url=http://example.com 'http://example.com' 'http://example.test' --recurse-objects --network --skip-columns=guid --skip-tables=wp_users
 	 *     else
-	 *         wp search-replace 'http://example.com' 'http://example.dev' --recurse-objects --skip-columns=guid --skip-tables=wp_users
+	 *         wp search-replace 'http://example.com' 'http://example.test' --recurse-objects --skip-columns=guid --skip-tables=wp_users
 	 *     fi
 	 */
 	public function __invoke( $args, $assoc_args ) {


### PR DESCRIPTION
Google owns and sells the `.dev` TLD, and .dev domains have strict HSTS enforcements, so use `.test` instead which is protected by an RFC, and has no restrictions on what kind of IPs it can be mapped to