### PR TITLE
PHPCS: fix up the code base [9] - one property per statement

### DIFF
--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -7,7 +7,8 @@ use Exception;
 
 class SearchReplacer {
 
-	private $from, $to;
+	private $from;
+	private $to;
 	private $recurse_objects;
 	private $regex;
 	private $regex_flags;


### PR DESCRIPTION
Fixes relate to the following rules:
* Declare only one property per statement.