### PR TITLE
Verify and whitelist SQL escaping

### DIFF
--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -321,6 +321,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 			if ( $this->export_handle ) {
 				fwrite( $this->export_handle, "\nDROP TABLE IF EXISTS $table_sql;\n" );
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
 				$row = $wpdb->get_row( "SHOW CREATE TABLE $table_sql", ARRAY_N );
 				fwrite( $this->export_handle, $row[1] . ";\n" );
 				list( $table_report, $total_rows ) = $this->php_export_table( $table, $old, $new );
@@ -367,6 +368,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 				if ( ! $php_only && ! $this->regex ) {
 					$col_sql          = self::esc_sql_ident( $col );
 					$wpdb->last_error = '';
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
 					$serial_row       = $wpdb->get_row( "SELECT * FROM $table_sql WHERE $col_sql REGEXP '^[aiO]:[1-9]' LIMIT 1" );
 					// When the regex triggers an error, we should fall back to PHP
 					if ( false !== strpos( $wpdb->last_error, 'ERROR 1139' ) ) {
@@ -492,12 +494,14 @@ class Search_Replace_Command extends WP_CLI_Command {
 			if ( $this->log_handle ) {
 				$count = $this->log_sql_diff( $col, $primary_keys, $table, $old, $new );
 			} else {
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
 				$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT($col_sql) FROM $table_sql WHERE $col_sql LIKE BINARY %s;", '%' . self::esc_like( $old ) . '%' ) );
 			}
 		} else {
 			if ( $this->log_handle ) {
 				$this->log_sql_diff( $col, $primary_keys, $table, $old, $new );
 			}
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
 			$count = $wpdb->query( $wpdb->prepare( "UPDATE $table_sql SET $col_sql = REPLACE($col_sql, %s, %s);", $old, $new ) );
 		}
 
@@ -518,6 +522,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$col_sql          = self::esc_sql_ident( $col );
 		$where            = $this->regex ? '' : " WHERE $col_sql" . $wpdb->prepare( ' LIKE BINARY %s', '%' . self::esc_like( $old ) . '%' );
 		$primary_keys_sql = implode( ',', self::esc_sql_ident( $primary_keys ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
 		$rows             = $wpdb->get_results( "SELECT {$primary_keys_sql} FROM {$table_sql} {$where}" );
 		foreach ( $rows as $keys ) {
 			$where_sql = '';
@@ -527,6 +532,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 				}
 				$where_sql .= self::esc_sql_ident( $k ) . ' = ' . self::esc_sql_value( $v );
 			}
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
 			$col_value = $wpdb->get_var( "SELECT {$col_sql} FROM {$table_sql} WHERE {$where_sql}" );
 			if ( '' === $col_value ) {
 				continue;
@@ -611,9 +617,11 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 				if ( method_exists( $wpdb, 'remove_placeholder_escape' ) ) {
 					// since 4.8.3
+					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- verified inputs above
 					$sql = $wpdb->remove_placeholder_escape( $wpdb->prepare( $sql, array_values( $values ) ) );
 				} else {
 					// 4.8.2 or less
+					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- verified inputs above
 					$sql = $wpdb->prepare( $sql, array_values( $values ) );
 				}
 
@@ -640,6 +648,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$text_columns    = array();
 		$all_columns     = array();
 		$suppress_errors = $wpdb->suppress_errors();
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
 		$results         = $wpdb->get_results( "DESCRIBE $table_sql" );
 		if ( ! empty( $results ) ) {
 			foreach ( $results as $col ) {
@@ -777,7 +786,11 @@ class Search_Replace_Command extends WP_CLI_Command {
 			$primary_keys_sql = '';
 		}
 
-		$results = $wpdb->get_results( $wpdb->prepare( "SELECT {$primary_keys_sql}`$col` FROM `$table` WHERE `$col` LIKE BINARY %s", '%' . self::esc_like( $old ) . '%' ), ARRAY_N );
+		$table_sql = self::esc_sql_ident( $table );
+		$col_sql   = self::esc_sql_ident( $col );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
+		$results = $wpdb->get_results( $wpdb->prepare( "SELECT {$primary_keys_sql}{$col_sql} FROM {$table_sql} WHERE {$col_sql} LIKE BINARY %s", '%' . self::esc_like( $old ) . '%' ), ARRAY_N );
 		if ( empty( $results ) ) {
 			return 0;
 		}

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -321,8 +321,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 			if ( $this->export_handle ) {
 				fwrite( $this->export_handle, "\nDROP TABLE IF EXISTS $table_sql;\n" );
+
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
 				$row = $wpdb->get_row( "SHOW CREATE TABLE $table_sql", ARRAY_N );
+
 				fwrite( $this->export_handle, $row[1] . ";\n" );
 				list( $table_report, $total_rows ) = $this->php_export_table( $table, $old, $new );
 				if ( $this->report ) {
@@ -368,8 +370,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 				if ( ! $php_only && ! $this->regex ) {
 					$col_sql          = self::esc_sql_ident( $col );
 					$wpdb->last_error = '';
+
 					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
-					$serial_row       = $wpdb->get_row( "SELECT * FROM $table_sql WHERE $col_sql REGEXP '^[aiO]:[1-9]' LIMIT 1" );
+					$serial_row = $wpdb->get_row( "SELECT * FROM $table_sql WHERE $col_sql REGEXP '^[aiO]:[1-9]' LIMIT 1" );
+
 					// When the regex triggers an error, we should fall back to PHP
 					if ( false !== strpos( $wpdb->last_error, 'ERROR 1139' ) ) {
 						$serial_row = true;
@@ -522,8 +526,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$col_sql          = self::esc_sql_ident( $col );
 		$where            = $this->regex ? '' : " WHERE $col_sql" . $wpdb->prepare( ' LIKE BINARY %s', '%' . self::esc_like( $old ) . '%' );
 		$primary_keys_sql = implode( ',', self::esc_sql_ident( $primary_keys ) );
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
-		$rows             = $wpdb->get_results( "SELECT {$primary_keys_sql} FROM {$table_sql} {$where}" );
+		$rows = $wpdb->get_results( "SELECT {$primary_keys_sql} FROM {$table_sql} {$where}" );
+
 		foreach ( $rows as $keys ) {
 			$where_sql = '';
 			foreach ( (array) $keys as $k => $v ) {
@@ -532,8 +538,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 				}
 				$where_sql .= self::esc_sql_ident( $k ) . ' = ' . self::esc_sql_value( $v );
 			}
+
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
 			$col_value = $wpdb->get_var( "SELECT {$col_sql} FROM {$table_sql} WHERE {$where_sql}" );
+
 			if ( '' === $col_value ) {
 				continue;
 			}
@@ -648,8 +656,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$text_columns    = array();
 		$all_columns     = array();
 		$suppress_errors = $wpdb->suppress_errors();
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
-		$results         = $wpdb->get_results( "DESCRIBE $table_sql" );
+		$results = $wpdb->get_results( "DESCRIBE $table_sql" );
+
 		if ( ! empty( $results ) ) {
 			foreach ( $results as $col ) {
 				if ( 'PRI' === $col->Key ) {
@@ -791,6 +801,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- escaped through self::esc_sql_ident
 		$results = $wpdb->get_results( $wpdb->prepare( "SELECT {$primary_keys_sql}{$col_sql} FROM {$table_sql} WHERE {$col_sql} LIKE BINARY %s", '%' . self::esc_like( $old ) . '%' ), ARRAY_N );
+
 		if ( empty( $results ) ) {
 			return 0;
 		}


### PR DESCRIPTION
Because we are doing a lot of manual assembly of SQL strings, PHPCS & WPCS do not pick up on all the actual escaping that is happening.

I went through all statements and made sure that they all escape as needed before whitelisting them.