### PR TITLE
Remove unneeded condition

### DIFF
--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -544,9 +544,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 			}
 
 			if ( $this->dry_run ) {
-				if ( $value != $col_value ) {
-					$count++;
-				}
+				$count++;
 			} else {
 				$where = array();
 				foreach ( (array) $keys as $k => $v ) {


### PR DESCRIPTION
I originally meant to turn the loose comparison into a strict one here, but afaict, the condition is useless, as we already have the opposite check with a `continue` above. It would always be true anyway.