### PR TITLE
Implement CS checking based on the WPCliCS ruleset

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ vendor/
 *.swp
 composer.lock
 *.log
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "wp-cli/db-command": "^1.3 || ^2",
         "wp-cli/entity-command": "^1.3 || ^2",
         "wp-cli/extension-command": "^1.2 || ^2",
-        "wp-cli/wp-cli-tests": "^2.0.7"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-search-replace">
+	<description>Custom ruleset for WP-CLI search-replace-command</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
+
+	<!-- What to scan. -->
+	<file>.</file>
+
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS">
+		<!-- Can't be helped as WP itself uses these functions for the data being adjusted. -->
+		<exclude name="WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize"/>
+		<exclude name="WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize"/>
+	</rule>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\Search"/><!-- Namespaces. -->
+				<element value="wpcli_search"/><!-- Global variables and such. -->
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Exclude existing classes and namespaces from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>*/src/Search_Replace_Command\.php$</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound">
+		<exclude-pattern>*/src/WP_CLI/SearchReplacer\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Allow for some MySQL native non-snake-case properties.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#mixed-case-property-name-exceptions
+		 Related: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1623 -->
+	<rule ref="WordPress.NamingConventions.ValidVariableName">
+		<properties>
+			<property name="customPropertiesWhitelist" type="array">
+				<element value="Key"/>
+				<element value="Field"/>
+				<element value="Type"/>
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -200,6 +200,8 @@ class Search_Replace_Command extends WP_CLI_Command {
 			$search_regex .= $old;
 			$search_regex .= $this->regex_delimiter;
 			$search_regex .= $this->regex_flags;
+
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Preventing a warning when testing the regex.
 			if ( false === @preg_match( $search_regex, '' ) ) {
 				if ( $default_regex_delimiter ) {
 					$flags_msg = $this->regex_flags ? "flags '$this->regex_flags'" : 'no flags';
@@ -236,6 +238,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 				}
 			}
 			$export_insert_size = WP_CLI\Utils\get_flag_value( $assoc_args, 'export_insert_size', 50 );
+			// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- See the code, this is deliberate.
 			if ( (int) $export_insert_size == $export_insert_size && $export_insert_size > 0 ) {
 				$this->export_insert_size = $export_insert_size;
 			}
@@ -691,7 +694,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 			// 4.0
 			$old = $wpdb->esc_like( $old );
 		} else {
-			// 3.9 or less
+			// phpcs:ignore WordPress.WP.DeprecatedFunctions.like_escapeFound -- BC-layer for WP 3.9 or less.
 			$old = like_escape( esc_sql( $old ) ); // Note: this double escaping is actually necessary, even though `esc_like()` will be used in a `prepare()`.
 		}
 

--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -136,7 +136,7 @@ class SearchReplacer {
 			if ( $serialised ) {
 				return serialize( $data );
 			}
-		} catch ( Exception $error ) {
+		} catch ( Exception $error ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberally empty.
 
 		}
 


### PR DESCRIPTION
This basically adds a PHPCS ruleset using the new WPCliCSstandard and adds a few select whitelist comments.

Please see the individual commits for more detail.

The build for this PR won't be able to pass until wp-cli-tests 2.1 has been released, upon which time, the build can just be restarted and should be green ;-)

Fixes #114