### PR TITLE
Adds wildcards support to skip-tables parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ change primary key values.
 
 	[--skip-tables=<tables>]
 		Do not perform the replacement on specific tables. Use commas to
-		specify multiple tables.
+		specify multiple tables. Wildcards are supported, e.g. `'wp_*options'` or `'wp_post*'`.
 
 	[--skip-columns=<columns>]
 		Do not perform the replacement on specific columns. Use commas to

--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -26,6 +26,20 @@ Feature: Search / replace with file export
       INSERT INTO `wp_options`
       """
 
+    When I run `wp search-replace example.com example.net --skip-tables=wp_opt\?ons,wp_post\* --export`
+    Then STDOUT should not contain:
+      """
+      wp_posts
+      """
+    And STDOUT should not contain:
+      """
+      wp_postmeta
+      """
+    And STDOUT should not contain:
+      """
+      wp_options
+      """
+
     When I run `wp search-replace example.com example.net --skip-columns=option_value --export`
     Then STDOUT should contain:
       """

--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -39,6 +39,10 @@ Feature: Search / replace with file export
       """
       wp_options
       """
+    And STDOUT should contain:
+      """
+      wp_users
+      """
 
     When I run `wp search-replace example.com example.net --skip-columns=option_value --export`
     Then STDOUT should contain:

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -24,6 +24,10 @@ Feature: Do global search/replace
       """
       wp_postmeta
       """
+    And STDOUT should contain:
+      """
+      wp_users
+      """
 
     When I run `wp search-replace foo bar --skip-columns=guid`
     Then STDOUT should not contain:

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -15,6 +15,16 @@ Feature: Do global search/replace
       wp_posts
       """
 
+    When I run `wp search-replace foo bar --skip-tables=wp_post\*`
+    Then STDOUT should not contain:
+      """
+      wp_posts
+      """
+    And STDOUT should not contain:
+      """
+      wp_postmeta
+      """
+
     When I run `wp search-replace foo bar --skip-columns=guid`
     Then STDOUT should not contain:
       """

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -77,7 +77,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 *
 	 * [--skip-tables=<tables>]
 	 * : Do not perform the replacement on specific tables. Use commas to
-	 * specify multiple tables.
+	 * specify multiple tables. Wildcards are supported, e.g. `'wp_*options'` or `'wp_post*'`.
 	 *
 	 * [--skip-columns=<columns>]
 	 * : Do not perform the replacement on specific columns. Use commas to
@@ -316,8 +316,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 		foreach ( $tables as $table ) {
 
-			if ( in_array( $table, $this->skip_tables, true ) ) {
-				continue;
+			foreach ( $this->skip_tables as $skip_table ) {
+				if ( fnmatch( $skip_table, $table ) ) {
+					continue 2;
+				}
 			}
 
 			$table_sql = self::esc_sql_ident( $table );


### PR DESCRIPTION
This little PR permits to use wildcards in `skip-tables` option like this : `--skip-tables=wp_post*`.

Useful for example when we want to skip a plugin's tables which begin by a prefix
