### PR TITLE
Improve error message on regex check

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -195,13 +195,10 @@ Feature: Do global search/replace
   Scenario: Regex search/replace with a incorrect `--regex-flags`
     Given a WP install
     When I try `wp search-replace '(Hello)\s(world)' '$2, $1' --regex --regex-flags='kppr'`
-    Then STDERR should contain:
+    Then STDERR should be:
       """
-      (Hello)\s(world)
-      """
-    And STDERR should contain:
-      """
-      kppr
+      Error: The regex pattern '(Hello)\s(world)' with default delimiter 'chr(1)' and flags 'kppr' fails.
+      preg_match(): Unknown modifier 'k'.
       """
     And the return code should be 1
 
@@ -403,6 +400,7 @@ Feature: Do global search/replace
     Then STDERR should be:
       """
       Error: The regex '1HTTP://EXAMPLE.COM1i' fails.
+      preg_match(): Delimiter must not be alphanumeric or backslash.
       """
     And the return code should be 1
 
@@ -410,6 +408,7 @@ Feature: Do global search/replace
     Then STDERR should be:
       """
       Error: The regex pattern 'regex error)' with default delimiter 'chr(1)' and no flags fails.
+      preg_match(): Compilation failed: unmatched parentheses at offset 11.
       """
     And the return code should be 1
 
@@ -417,6 +416,7 @@ Feature: Do global search/replace
     Then STDERR should be:
       """
       Error: The regex pattern 'regex error)' with default delimiter 'chr(1)' and flags 'u' fails.
+      preg_match(): Compilation failed: unmatched parentheses at offset 11.
       """
     And the return code should be 1
 
@@ -424,6 +424,7 @@ Feature: Do global search/replace
     Then STDERR should be:
       """
       Error: The regex '/regex error)/' fails.
+      preg_match(): Compilation failed: unmatched parentheses at offset 11.
       """
     And the return code should be 1
 
@@ -431,6 +432,7 @@ Feature: Do global search/replace
     Then STDERR should be:
       """
       Error: The regex '/regex error)/u' fails.
+      preg_match(): Compilation failed: unmatched parentheses at offset 11.
       """
     And the return code should be 1
 

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -405,34 +405,62 @@ Feature: Do global search/replace
     And the return code should be 1
 
     When I try `wp search-replace 'regex error)' '' --regex`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
       Error: The regex pattern 'regex error)' with default delimiter 'chr(1)' and no flags fails.
-      preg_match(): Compilation failed: unmatched parentheses at offset 11.
+      """
+    And STDERR should contain:
+      """
+      preg_match(): Compilation failed:
+      """
+    And STDERR should contain:
+      """
+      at offset 11
       """
     And the return code should be 1
 
     When I try `wp search-replace 'regex error)' '' --regex --regex-flags=u`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
       Error: The regex pattern 'regex error)' with default delimiter 'chr(1)' and flags 'u' fails.
-      preg_match(): Compilation failed: unmatched parentheses at offset 11.
+      """
+    And STDERR should contain:
+      """
+      preg_match(): Compilation failed:
+      """
+    And STDERR should contain:
+      """
+      at offset 11
       """
     And the return code should be 1
 
     When I try `wp search-replace 'regex error)' '' --regex --regex-delimiter=/`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
       Error: The regex '/regex error)/' fails.
-      preg_match(): Compilation failed: unmatched parentheses at offset 11.
+      """
+    And STDERR should contain:
+      """
+      preg_match(): Compilation failed:
+      """
+    And STDERR should contain:
+      """
+      at offset 11
       """
     And the return code should be 1
 
     When I try `wp search-replace 'regex error)' '' --regex --regex-delimiter=/ --regex-flags=u`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
       Error: The regex '/regex error)/u' fails.
-      preg_match(): Compilation failed: unmatched parentheses at offset 11.
+      """
+    And STDERR should contain:
+      """
+      preg_match(): Compilation failed:
+      """
+    And STDERR should contain:
+      """
+      at offset 11
       """
     And the return code should be 1
 

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -203,13 +203,15 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Preventing a warning when testing the regex.
 			if ( false === @preg_match( $search_regex, '' ) ) {
+				$error              = error_get_last();
+				$preg_error_message = ( ! empty( $error ) && array_key_exists( 'message', $error ) ) ? "\n{$error['message']}." : '';
 				if ( $default_regex_delimiter ) {
 					$flags_msg = $this->regex_flags ? "flags '$this->regex_flags'" : 'no flags';
 					$msg       = "The regex pattern '$old' with default delimiter 'chr(1)' and {$flags_msg} fails.";
 				} else {
 					$msg = "The regex '$search_regex' fails.";
 				}
-				WP_CLI::error( $msg );
+				WP_CLI::error( $msg . $preg_error_message );
 			}
 		}
 


### PR DESCRIPTION
ref: https://github.com/wp-cli/search-replace-command/issues/66

Get error message from `error_get_last()` , and display it on STDERR.