### PR TITLE
Restore blogdescription to fix test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,10 @@
     },
     "config": {
         "process-timeout": 7200,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -929,7 +929,7 @@ Feature: Do global search/replace
 
   Scenario: Logging with prefixes and custom colors
     Given a WP install
-    And I run `wp option set blogdescription 'Just another WordPress site'
+    And I run `wp option set blogdescription 'Just another WordPress site'`
 
     When I run `WP_CLI_SEARCH_REPLACE_LOG_PREFIXES='- ,+ ' wp search-replace Just Yet --dry-run --log`
     Then STDOUT should contain:

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -929,6 +929,7 @@ Feature: Do global search/replace
 
   Scenario: Logging with prefixes and custom colors
     Given a WP install
+    And I run `wp option set blogdescription 'Just another WordPress site'
 
     When I run `WP_CLI_SEARCH_REPLACE_LOG_PREFIXES='- ,+ ' wp search-replace Just Yet --dry-run --log`
     Then STDOUT should contain:


### PR DESCRIPTION
Set a `blogdescription` in tests after it was set to empty string in WordPress core https://github.com/WordPress/wordpress-develop/commit/66dba67484a2e0aaa7bcafc0fa70b33d64448f74 this fixes test failure in https://github.com/wp-cli/automated-tests/runs/7797876665?check_suite_focus=true#step:14:64