### PR TITLE
Add further suppression of warnings and notices

### DIFF
--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -83,7 +83,13 @@ class SearchReplacer {
 				}
 			}
 
+			// The error suppression operator is not enough in some cases, so we disable
+			// reporting of notices and warnings as well.
+			$error_reporting = error_reporting();
+			error_reporting( $error_reporting & ~E_NOTICE & ~E_WARNING );
 			$unserialized = is_string( $data ) ? @unserialize( $data ) : false;
+			error_reporting( $error_reporting );
+
 			if ( false !== $unserialized ) {
 				$data = $this->run_recursively( $unserialized, true, $recursion_level + 1 );
 			} elseif ( is_array( $data ) ) {


### PR DESCRIPTION
Under some circumstances, the error suppression operator (`@`) is not enough to keep the `unserialize` from throwing warnings or notices. These then end up in the exported SQL file and corrupt the replacements.

This PR changes the error reporting levels globally for the `unserialize` call to get rid of these unwanted notices and warnings.