### PR TITLE
Make is_text_col's search case-insensitive for sqlite support

### DIFF
--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -712,7 +712,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 	private static function is_text_col( $type ) {
 		foreach ( array( 'text', 'varchar' ) as $token ) {
-			if ( false !== strpos( $type, $token ) ) {
+			if ( false !== stripos( $type, $token ) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
When using wp-sqlite-db as the back end for WordPress, wpcli's `search-replace` command fails because wp-sqlite-db returns text column types as `TEXT`, and wpcli search-replace checks whether a column is textual in `is_text_col` with `strpos` for "text" or "varchar". If this were `stripos` instead of `strpos` then this problem would be resolved, which would be nice, and I don't believe there would be any backward compatibility implications. So, here's a one-character PR :-)

(Of course, sqlite as backend isn't actually supported, but this is a fairly small change which should make things better for that without affecting the mainline code. I've also proposed https://github.com/aaemnnosttv/wp-sqlite-db/pull/56 to wp-sqlite-db to have that return lowercase "text" for column types as well, thus hopefully fixing the problem at both ends.)

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
