### PR TITLE
Address long-running queries and OOM contributor in PHP replacement

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -1149,7 +1149,7 @@ Feature: Do global search/replace
       Success:
       """
 
-  Scenario: Chunking works without skipping lines
+  Scenario: Chunking a precise search and replace works without skipping lines
     Given a WP install
     And a create_sql_file.sh file:
       """
@@ -1186,6 +1186,48 @@ Feature: Do global search/replace
       """
 
     When I run `wp search-replace 'abc' 'def' --all-tables-with-prefix --skip-columns=guid,domain --precise`
+    Then STDOUT should contain:
+      """
+      Success: Made 0 replacements.
+      """
+
+  Scenario: Chunking a regex search and replace works without skipping lines
+    Given a WP install
+    And a create_sql_file.sh file:
+      """
+      #!/bin/bash
+      echo "CREATE TABLE \`wp_123_test\` (\`key\` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT, \`text\` TEXT, PRIMARY KEY (\`key\`) );" > test_db.sql
+      echo "INSERT INTO \`wp_123_test\` (\`text\`) VALUES" >> test_db.sql
+      index=1
+      while [[ $index -le 199 ]];
+      do
+        echo "('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc')," >> test_db.sql
+        index=`expr $index + 1`
+      done
+        echo "('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc');" >> test_db.sql
+      """
+    And I run `bash create_sql_file.sh`
+    And I run `wp db query "SOURCE test_db.sql;"`
+
+    When I run `wp search-replace --dry-run 'abc' 'def' --all-tables-with-prefix --skip-columns=guid,domain --regex`
+    Then STDOUT should contain:
+      """
+      Success: 2000 replacements to be made.
+      """
+
+    When I run `wp search-replace 'abc' 'def' --all-tables-with-prefix --skip-columns=guid,domain --regex`
+    Then STDOUT should contain:
+      """
+      Success: Made 2000 replacements.
+      """
+
+    When I run `wp search-replace --dry-run 'abc' 'def' --all-tables-with-prefix --skip-columns=guid,domain --regex`
+    Then STDOUT should contain:
+      """
+      Success: 0 replacements to be made.
+      """
+
+    When I run `wp search-replace 'abc' 'def' --all-tables-with-prefix --skip-columns=guid,domain --regex`
     Then STDOUT should contain:
       """
       Success: Made 0 replacements.


### PR DESCRIPTION
This change makes PHP replacement queries and memory usage more efficient in order to address issues we've encountered with long-running queries and OOM conditions with certain sites.

It improves the primary key SELECT queries by eliminating the use of OFFSET because OFFSET requires that the database consider all rows up to OFFSET before taking rows up to the LIMIT. This can make queries become slower as OFFSET increases. The new SELECT query relies on primary key conditions to more efficiently eliminate previous rows from consideration. This way, the database can use an index to identify rows with keys greater than those of the previous chunk and then take rows from that set up to the LIMIT.

It improves memory usage by doing updates along the way rather than storing all a column's updated values in memory until the end. At Automattic, when we limit search-replace to 4GB of memory, we sometimes exceed that limit for large sites. It's possible there are other things that contribute to high memory usage within the search-replace command, but as a first step, we can reduce memory requirements by no longer keeping all updated column values in memory simultaneously.

This is a resurrection of #176 which was closed so we could exercise these updates in production before sharing them with the community. The `--regex` path of this change has been used in production for the last 3-4 months, and we have encountered no issues so far.

Prior to this PR, there were tests for the chunked `--precise` search-replace but none for the chunked `--regex` path, so this PR adds tests for chunked `--regex` replacement based on the `--precise` tests.

