### PR TITLE
Fix regex invalid delimiter test for PHP 8.2

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -456,30 +456,17 @@ Feature: Do global search/replace
       """
     And the return code should be 1
 
-  @less-than-php-8.2
   Scenario: Search replace with an invalid regex delimiter
     Given a WP install
 
+    # Exact preg_match() error changed with PHP 8.2+ (added NUL).
     When I try `wp search-replace 'HTTPS://EXAMPLE.COM' 'https://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='1'`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
       Error: The regex '1HTTPS://EXAMPLE.COM1i' fails.
-      preg_match(): Delimiter must not be alphanumeric or backslash.
+      preg_match(): Delimiter must not be alphanumeric
       """
     And the return code should be 1
-
-  @require-php-8.2
-  Scenario: Search replace with an invalid regex delimiter
-    Given a WP install
-
-    When I try `wp search-replace 'HTTPS://EXAMPLE.COM' 'https://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='1'`
-    Then STDERR should be:
-      """
-      Error: The regex '1HTTPS://EXAMPLE.COM1i' fails.
-      preg_match(): Delimiter must not be alphanumeric, backslash, or NUL.
-      """
-    And the return code should be 1
-
   Scenario: Formatting as count-only
     Given a WP install
     And I run `wp option set foo 'ALPHA.example.com'`

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -396,6 +396,19 @@ Feature: Do global search/replace
       https://example.com
       """
 
+    # NOTE: The preg_match() error message is a substring of the actual message that matches across supported PHP versions.
+    # In PHP 8.2, the error message changed from
+    #   "preg_match(): Delimiter must not be alphanumeric or backslash."
+    # to
+    #   "preg_match(): Delimiter must not be alphanumeric, backslash, or NUL"
+    When I try `wp search-replace 'HTTPS://EXAMPLE.COM' 'https://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='1'`
+    Then STDERR should contain:
+      """
+      Error: The regex '1HTTPS://EXAMPLE.COM1i' fails.
+      preg_match(): Delimiter must not be alphanumeric
+      """
+    And the return code should be 1
+
     When I try `wp search-replace 'regex error)' '' --regex`
     Then STDERR should contain:
       """
@@ -456,17 +469,6 @@ Feature: Do global search/replace
       """
     And the return code should be 1
 
-  Scenario: Search replace with an invalid regex delimiter
-    Given a WP install
-
-    # Exact preg_match() error changed with PHP 8.2+ (added NUL).
-    When I try `wp search-replace 'HTTPS://EXAMPLE.COM' 'https://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='1'`
-    Then STDERR should contain:
-      """
-      Error: The regex '1HTTPS://EXAMPLE.COM1i' fails.
-      preg_match(): Delimiter must not be alphanumeric
-      """
-    And the return code should be 1
   Scenario: Formatting as count-only
     Given a WP install
     And I run `wp option set foo 'ALPHA.example.com'`

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -396,14 +396,6 @@ Feature: Do global search/replace
       https://example.com
       """
 
-    When I try `wp search-replace 'HTTPS://EXAMPLE.COM' 'https://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='1'`
-    Then STDERR should be:
-      """
-      Error: The regex '1HTTPS://EXAMPLE.COM1i' fails.
-      preg_match(): Delimiter must not be alphanumeric or backslash.
-      """
-    And the return code should be 1
-
     When I try `wp search-replace 'regex error)' '' --regex`
     Then STDERR should contain:
       """
@@ -461,6 +453,30 @@ Feature: Do global search/replace
     And STDERR should contain:
       """
       at offset 11
+      """
+    And the return code should be 1
+
+  @less-than-php-8.2
+  Scenario: Search replace with an invalid regex delimiter
+    Given a WP install
+
+    When I try `wp search-replace 'HTTPS://EXAMPLE.COM' 'https://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='1'`
+    Then STDERR should be:
+      """
+      Error: The regex '1HTTPS://EXAMPLE.COM1i' fails.
+      preg_match(): Delimiter must not be alphanumeric or backslash.
+      """
+    And the return code should be 1
+
+  @require-php-8.2
+  Scenario: Search replace with an invalid regex delimiter
+    Given a WP install
+
+    When I try `wp search-replace 'HTTPS://EXAMPLE.COM' 'https://example.jp/' wp_options --regex --regex-flags=i --regex-delimiter='1'`
+    Then STDERR should be:
+      """
+      Error: The regex '1HTTPS://EXAMPLE.COM1i' fails.
+      preg_match(): Delimiter must not be alphanumeric, backslash, or NUL.
       """
     And the return code should be 1
 


### PR DESCRIPTION
It looks like the invalid-regex-delimiter test is failing under PHP 8.2. This was noticed because of [a failing test under another PR](https://github.com/wp-cli/search-replace-command/actions/runs/4931033960/jobs/8812678858?pr=180)(#180).

This PR fixes the test to deal with a changing preg_match() error message in PHP 8.2.

Behat is new to me, so perhaps there is a better way to approach this. But hopefully this is helpful.
