### PR TITLE
Fix search-replace for tables with composite primary keys

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -1163,6 +1163,15 @@ Feature: Do global search/replace
         index=`expr $index + 1`
       done
         echo "('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc');" >> test_db.sql
+      echo "CREATE TABLE \`wp_123_test_multikey\` (\`key1\` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT, \`key2\` INT(5) UNSIGNED NOT NULL, \`key3\` INT(5) UNSIGNED NOT NULL, \`text\` TEXT, PRIMARY KEY (\`key1\`,\`key2\`,\`key3\`) );" >> test_db.sql
+      echo "INSERT INTO \`wp_123_test_multikey\` (\`key2\`,\`key3\`,\`text\`) VALUES" >> test_db.sql
+      index=1
+      while [[ $index -le 204 ]];
+      do
+        echo "(0,0,'abc'),(1,1,'abc'),(2,2,'abc'),(3,3,'abc'),(4,4,'abc'),(5,0,'abc'),(6,1,'abc'),(7,2,'abc'),(8,3,'abc'),(9,4,'abc')," >> test_db.sql
+        index=`expr $index + 1`
+      done
+        echo "(0,0,'abc'),(1,1,'abc'),(2,2,'abc'),(3,3,'abc'),(4,4,'abc'),(5,0,'abc'),(6,1,'abc'),(7,2,'abc'),(8,3,'abc'),(9,4,'abc');" >> test_db.sql
       """
     And I run `bash create_sql_file.sh`
     And I run `wp db query "SOURCE test_db.sql;"`
@@ -1170,13 +1179,13 @@ Feature: Do global search/replace
     When I run `wp search-replace --dry-run 'abc' 'def' --all-tables-with-prefix --skip-columns=guid,domain --precise`
     Then STDOUT should contain:
       """
-      Success: 2000 replacements to be made.
+      Success: 4050 replacements to be made.
       """
 
     When I run `wp search-replace 'abc' 'def' --all-tables-with-prefix --skip-columns=guid,domain --precise`
     Then STDOUT should contain:
       """
-      Success: Made 2000 replacements.
+      Success: Made 4050 replacements.
       """
 
     When I run `wp search-replace --dry-run 'abc' 'def' --all-tables-with-prefix --skip-columns=guid,domain --precise`
@@ -1205,6 +1214,15 @@ Feature: Do global search/replace
         index=`expr $index + 1`
       done
         echo "('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc'),('abc');" >> test_db.sql
+      echo "CREATE TABLE \`wp_123_test_multikey\` (\`key1\` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT, \`key2\` INT(5) UNSIGNED NOT NULL, \`key3\` INT(5) UNSIGNED NOT NULL, \`text\` TEXT, PRIMARY KEY (\`key1\`,\`key2\`,\`key3\`) );" >> test_db.sql
+      echo "INSERT INTO \`wp_123_test_multikey\` (\`key2\`,\`key3\`,\`text\`) VALUES" >> test_db.sql
+      index=1
+      while [[ $index -le 204 ]];
+      do
+        echo "(0,0,'abc'),(1,1,'abc'),(2,2,'abc'),(3,3,'abc'),(4,4,'abc'),(5,0,'abc'),(6,1,'abc'),(7,2,'abc'),(8,3,'abc'),(9,4,'abc')," >> test_db.sql
+        index=`expr $index + 1`
+      done
+        echo "(0,0,'abc'),(1,1,'abc'),(2,2,'abc'),(3,3,'abc'),(4,4,'abc'),(5,0,'abc'),(6,1,'abc'),(7,2,'abc'),(8,3,'abc'),(9,4,'abc');" >> test_db.sql
       """
     And I run `bash create_sql_file.sh`
     And I run `wp db query "SOURCE test_db.sql;"`
@@ -1212,13 +1230,13 @@ Feature: Do global search/replace
     When I run `wp search-replace --dry-run 'abc' 'def' --all-tables-with-prefix --skip-columns=guid,domain --regex`
     Then STDOUT should contain:
       """
-      Success: 2000 replacements to be made.
+      Success: 4050 replacements to be made.
       """
 
     When I run `wp search-replace 'abc' 'def' --all-tables-with-prefix --skip-columns=guid,domain --regex`
     Then STDOUT should contain:
       """
-      Success: Made 2000 replacements.
+      Success: Made 4050 replacements.
       """
 
     When I run `wp search-replace --dry-run 'abc' 'def' --all-tables-with-prefix --skip-columns=guid,domain --regex`

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -612,7 +612,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 			foreach ( (array) $last_keys as $k => $v ) {
 				$where_key_conditions[] = self::esc_sql_ident( $k ) . ' > ' . self::esc_sql_value( $v );
 			}
-			$where_key = 'WHERE ' . implode( 'AND', $where_key_conditions );
+			$where_key = 'WHERE ' . implode( ' AND ', $where_key_conditions );
 		}
 
 		if ( $this->verbose && 'table' === $this->format ) {

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -604,14 +604,36 @@ class Search_Replace_Command extends WP_CLI_Command {
 			// Because we are ordering by primary keys from least to greatest,
 			// we can exclude previous chunks from consideration by adding greater-than conditions
 			// to insist the next chunk's keys must be greater than the last of this chunk's keys.
-			$last_keys            = end( $rows );
+			$last_row            = end( $rows );
+			$next_key_conditions = array();
+
+			// NOTE: For a composite key (X, Y, Z), selecting the next rows requires the following conditions:
+			// ( X = lastX AND Y = lastY AND Z > lastZ ) OR
+			// ( X = lastX AND Y > lastY ) OR
+			// ( X > lastX )
+			for ( $last_key_index = count( $primary_keys ) - 1; $last_key_index >= 0; $last_key_index-- ) {
+				$next_key_subconditions = array();
+
+				for ( $i = 0; $i <= $last_key_index; $i++ ) {
+					$k = $primary_keys[ $i ];
+					$v = $last_row->{ $k };
+
+					if ( $i < $last_key_index ) {
+						$next_key_subconditions[] = self::esc_sql_ident( $k ) . ' = ' . self::esc_sql_value( $v );
+					} else {
+						$next_key_subconditions[] = self::esc_sql_ident( $k ) . ' > ' . self::esc_sql_value( $v );
+					}
+				}
+
+				$next_key_conditions[] = '( ' . implode( ' AND ', $next_key_subconditions ) . ' )';
+			}
+
 			$where_key_conditions = array();
 			if ( $base_key_condition ) {
 				$where_key_conditions[] = $base_key_condition;
 			}
-			foreach ( (array) $last_keys as $k => $v ) {
-				$where_key_conditions[] = self::esc_sql_ident( $k ) . ' > ' . self::esc_sql_value( $v );
-			}
+			$where_key_conditions[] = '( ' . implode( ' OR ', $next_key_conditions ) . ' )';
+
 			$where_key = 'WHERE ' . implode( ' AND ', $where_key_conditions );
 		}
 


### PR DESCRIPTION
Fixes #182 

This PR addresses two bugs:
1. When a table has a composite key, precise and regex search-replace fails because of a SQL syntax error.
2. Once the cause of the SQL syntax error was addressed, there was another bug where, for a composite key (X, Y, Z) the next batch conditions were always X > lastX AND Y > lastY AND Z > lastZ. This condition can skip rows when ordering by X, Y, and Z because Y and Z may repeat values within different values of X. If we assume Y and Z always increase independently of one another, we will skip rows where previous Y and Z values repeat under subsequent values of X.

There are three commits under this PR. The first adds tests that will fail until the next two commits are applied. Please note that number of rows INSERTed for testing with composite primary keys is intentionally different than the number of rows used to test with single primary keys. The idea is to avoid symmetry to reduce the likelihood of the total count accidentally matching due to some other bug (e.g., a bug where composite key rows aren't replaced at all but single key rows are counted twice).

Perhaps it would be good to separate single key and composite key into dedicated scenarios, but so far, I have simply updated the precise and regex batch scenarios to also test with composite primary keys.

To test:
1. Check out this branch
2. `git revert --no-commit HEAD HEAD~1` to temporarily reverse both fixes
3. Run `composer test` and observe the failures due to SQL syntax errors
4. Restore branch with `git revert --abort`
5. `git revert --no-commit HEAD` to temporarily reverse the second fix
6. Run `composer test` and observe that the total number of replacements is 3000 rather than the expected total of 4050.
7. Restore branch with `git revert --abort`
8. Run `composer test` and note that all tests pass

