### PR TITLE
skip-revisions, select columns, callbacks = The forever reroll

### DIFF
--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -15,6 +15,7 @@ class SearchReplacer {
 	private $regex_delimiter;
 	private $regex_limit;
 	private $logging;
+	private $callback;
 	private $log_data;
 	private $max_recursion;
 
@@ -28,7 +29,7 @@ class SearchReplacer {
 	 * @param bool    $logging         Whether logging.
 	 * @param integer $regex_limit     The maximum possible replacements for each pattern in each subject string.
 	 */
-	public function __construct( $from, $to, $recurse_objects = false, $regex = false, $regex_flags = '', $regex_delimiter = '/', $logging = false, $regex_limit = -1 ) {
+	public function __construct( $from, $to, $recurse_objects = false, $regex = false, $regex_flags = '', $regex_delimiter = '/', $logging = false, $regex_limit = -1, $callback = false ) {
 		$this->from            = $from;
 		$this->to              = $to;
 		$this->recurse_objects = $recurse_objects;
@@ -37,6 +38,7 @@ class SearchReplacer {
 		$this->regex_delimiter = $regex_delimiter;
 		$this->regex_limit     = $regex_limit;
 		$this->logging         = $logging;
+		$this->callback        = $callback;
 		$this->clear_log_data();
 
 		// Get the XDebug nesting level. Will be zero (no limit) if no value is set
@@ -53,15 +55,15 @@ class SearchReplacer {
 	 *
 	 * @return array       The original array with all elements replaced as needed.
 	 */
-	public function run( $data, $serialised = false ) {
-		return $this->run_recursively( $data, $serialised );
+	public function run( $data, $serialised = false, $opts = [] ) {
+		return $this->run_recursively( $data, $serialised, 0, [], $opts );
 	}
 
 	/**
 	 * @param int          $recursion_level Current recursion depth within the original data.
 	 * @param array        $visited_data    Data that has been seen in previous recursion iterations.
 	 */
-	private function run_recursively( $data, $serialised, $recursion_level = 0, $visited_data = array() ) {
+	private function run_recursively( $data, $serialised, $recursion_level = 0, $visited_data = array(), $opts = [] ) {
 
 		// some unseriliased data cannot be re-serialised eg. SimpleXMLElements
 		try {
@@ -121,8 +123,14 @@ class SearchReplacer {
 					$search_regex .= $this->regex_delimiter;
 					$search_regex .= $this->regex_flags;
 
-					$result = preg_replace( $search_regex, $this->to, $data, $this->regex_limit );
-					if ( null === $result || PREG_NO_ERROR !== preg_last_error() ) {
+					$check = true; // Set to avoid bogus error on strpos
+
+					if ( $this->callback ) {
+						$result = \call_user_func( $this->callback, $data, $this->to, $search_regex, $opts );
+					} else {
+						$result = preg_replace( $search_regex, $this->to, $data, $this->regex_limit );
+					}
+					if ( ( null === $result || PREG_NO_ERROR !== preg_last_error() ) && null !== $check ) {
 						\WP_CLI::warning(
 							sprintf(
 								'The provided regular expression threw a PCRE error - %s',
@@ -130,10 +138,26 @@ class SearchReplacer {
 							)
 						);
 					}
-					$data = $result;
+				} elseif ( $this->callback ) {
+					if ( strpos( $data, $this->from ) !== false ) {
+						$result = \call_user_func( $this->callback, $data, $this->to, $opts );
+					} else {
+						// We can skip calling the function here. It must still be set so we don't remove text.
+						$result = $data;
+					}
 				} else {
-					$data = str_replace( $this->from, $this->to, $data );
+					$result = str_replace( $this->from, $this->to, $data );
 				}
+
+				if ( $this->callback ) {
+					if ( false === $result || is_wp_error( $result ) ) {
+						\WP_CLI::error( 'The callback function threw an error. Stopping operation.' );
+					} elseif ( ! is_string( $result ) ) {
+						\WP_CLI::error( 'The callback function did not return a string. Stopping operation.' );
+					}
+				}
+
+				$data = $result;
 				if ( $this->logging && $old_data !== $data ) {
 					$this->log_data[] = $old_data;
 				}


### PR DESCRIPTION
### Replacement callback & row-based filtering (include/exclude posts revisions)

- Replacing revisions is confusing (total replacements count) and annoying
- Specifying rows/columns/custom `--where` expression has been a long requested feature (for more than 6 years)
- Extra flexibility regarding replacements (custom PHP callback) has also been requested multiple times

---

- Added --where flag to finely select rows aimed for replacement
- Added --revision / --no-revision
- Added --callback

 
- Reroll of #104 (**Dec 2018**) and #128 (**Sept 2019**) (Feature: Call user function with --callback flag #104 )
- Fix #125 (Introduce `--where` flag), close #142
- Preliminary work for #127 (Callback access to current primary key & column)


I plea upstream to consider the PR without incurring X more extra rerolls to contributors (who already pumped dozens of hours of man work into the useless and error-prone task of rebasing) [The diff talks for itself]


This PR lack tests: **Yes** because tests are always hard and painful to write for external contributors but less time-consuming/easier to write correctly by long-time codebase maintainers.

Is this feature better inside (without automated tests) rather than unavaiable? I believe so.
