### PR TITLE
PHP 8.2 Deprecation: Fix creation of dynamic property.

### DIFF
--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -31,6 +31,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	private $log_prefixes       = array( '< ', '> ' );
 	private $log_colors;
 	private $log_encoding;
+	private $start_time;
 
 	/**
 	 * Searches/replaces strings in the database.


### PR DESCRIPTION
If I use the search-replace command `wp search-replace 'aaa' 'bbb' wp_users --format=table --verbose --dry-run` with WP CLI 2.9.0 and PHP 8.2.14, I get the warning:

`Deprecated: Creation of dynamic property Search_Replace_Command::$start_time is deprecated in /vendor/wp-cli/search-replace-command/src/Search_Replace_Command.php on line 381`

This PR fixes the warning.