### PR TITLE
Fix tests after change in WordPress trunk

### DIFF
--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -51,13 +51,19 @@ Feature: Search / replace with file export
     Then STDOUT should contain:
       """
       INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES{SPACE}
-    ('1', 'siteurl', 'https://example.com', 'yes'),
+      """
+    And STDOUT should contain:
+      """
+    ('1', 'siteurl', 'https://example.com'
       """
 
     When I run `wp search-replace example.com example.net --skip-columns=option_value --export --export_insert_size=1`
     Then STDOUT should contain:
       """
-      ('1', 'siteurl', 'https://example.com', 'yes');
+      ('1', 'siteurl', 'https://example.com'
+      """
+    And STDOUT should contain:
+      """
     INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES{SPACE}
       """
 

--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -14,7 +14,7 @@ Feature: Search / replace with file export
       """
     And STDOUT should contain:
       """
-      ('1', 'siteurl', 'https://example.net', 'yes'),
+      ('1', 'siteurl', 'https://example.net',
       """
 
     When I run `wp option get home`


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Improve the test case after https://core.trac.wordpress.org/changeset/58105 to address failures.

Simply removes the bits with the autoload value from the assertions.

The alternative would be to use a different value depending on the WP version but that seems overkill.
