### PR TITLE
Fix test for WordPress trunk

### DIFF
--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -14,7 +14,7 @@ Feature: Search / replace with file export
       """
     And STDOUT should contain:
       """
-      ('1', 'siteurl', 'https://example.net',
+      'siteurl', 'https://example.net',
       """
 
     When I run `wp option get home`

--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -54,13 +54,13 @@ Feature: Search / replace with file export
       """
     And STDOUT should contain:
       """
-    ('1', 'siteurl', 'https://example.com'
+    'siteurl', 'https://example.com'
       """
 
     When I run `wp search-replace example.com example.net --skip-columns=option_value --export --export_insert_size=1`
     Then STDOUT should contain:
       """
-      ('1', 'siteurl', 'https://example.com'
+      'siteurl', 'https://example.com'
       """
     And STDOUT should contain:
       """


### PR DESCRIPTION
`siteurl` is not necessarily the first row in `wp_options`.

It appears that other options such as `cron` can be first.

This removes the option ID from the assertion, as it is not relevant.

We only want to verify that the site URL changed.
