### PR TITLE
Add smart URL transformation support for search-replace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ change primary key values.
 		specify multiple columns.
 
 	[--smart-url]
-		Enable smart URL mode. Automatically skips 75+ WordPress core columns
+		Enable smart URL mode. Automatically skips dozens of WordPress core columns
 		that cannot contain URLs (like post_type, post_status, user_pass, etc.),
 		significantly improving performance for URL replacements. This is
 		particularly useful when migrating sites or changing domain names.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contr
 ## Using
 
 ~~~
-wp search-replace <old> <new> [<table>...] [--dry-run] [--network] [--all-tables-with-prefix] [--all-tables] [--export[=<file>]] [--export_insert_size=<rows>] [--skip-tables=<tables>] [--skip-columns=<columns>] [--include-columns=<columns>] [--precise] [--recurse-objects] [--verbose] [--regex] [--regex-flags=<regex-flags>] [--regex-delimiter=<regex-delimiter>] [--regex-limit=<regex-limit>] [--format=<format>] [--report] [--report-changed-only] [--log[=<file>]] [--before_context=<num>] [--after_context=<num>]
+wp search-replace <old> <new> [<table>...] [--dry-run] [--network] [--all-tables-with-prefix] [--all-tables] [--export[=<file>]] [--export_insert_size=<rows>] [--skip-tables=<tables>] [--skip-columns=<columns>] [--include-columns=<columns>] [--smart-url] [--analyze-tables] [--precise] [--recurse-objects] [--verbose] [--regex] [--regex-flags=<regex-flags>] [--regex-delimiter=<regex-delimiter>] [--regex-limit=<regex-limit>] [--format=<format>] [--report] [--report-changed-only] [--log[=<file>]] [--before_context=<num>] [--after_context=<num>]
 ~~~
 
 Searches through all rows in a selection of tables and replaces
@@ -72,6 +72,23 @@ change primary key values.
 	[--include-columns=<columns>]
 		Perform the replacement on specific columns. Use commas to
 		specify multiple columns.
+
+	[--smart-url]
+		Enable smart URL mode. Automatically skips 75+ WordPress core columns
+		that cannot contain URLs (like post_type, post_status, user_pass, etc.),
+		significantly improving performance for URL replacements. This is
+		particularly useful when migrating sites or changing domain names.
+		Performance: ~34% faster on large databases.
+		Note: This flag is automatically enabled when the search string starts
+		with http:// or https://. Use --verbose to see which columns are skipped.
+
+	[--analyze-tables]
+		Enable advanced table analysis mode. Analyzes MySQL column datatypes
+		to automatically skip non-text columns (integers, dates, enums, etc.)
+		and columns matching common WordPress-style naming patterns (e.g. `*_id`,
+		`*_count`, `*_status`, etc.) in addition to the static skip list. Useful
+		for plugin tables with custom schemas. Requires --smart-url to be enabled.
+		Note: Adds a small overhead for table introspection.
 
 	[--precise]
 		Force the use of PHP (instead of SQL) which is more thorough,
@@ -138,6 +155,12 @@ change primary key values.
 
     # Search/replace to a SQL file without transforming the database
     $ wp search-replace foo bar --export=database.sql
+
+    # URL replacement with smart column skipping (faster for URL changes)
+    $ wp search-replace 'http://example.test' 'http://example.com' --smart-url
+
+    # URL replacement with advanced table analysis for plugin tables
+    $ wp search-replace 'http://old.test' 'http://new.test' --smart-url --analyze-tables
 
     # Bash script: Search/replace production to development url (multisite compatible)
     #!/bin/bash

--- a/features/search-replace-url.feature
+++ b/features/search-replace-url.feature
@@ -1,0 +1,634 @@
+Feature: URL-optimized search/replace with smart column skipping
+
+  @require-mysql
+  Scenario: Basic URL search/replace with smart column skipping
+    Given a WP install
+
+    When I run `wp post create --post_title="Test Post" --post_content="Visit http://example.test for more" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace 'http://example.test' 'http://example.com' --smart-url --dry-run --verbose`
+    Then STDOUT should contain:
+      """
+      Smart URL mode
+      """
+    And STDOUT should contain:
+      """
+      wp_posts
+      """
+    And STDOUT should contain:
+      """
+      post_content
+      """
+
+  @require-mysql
+  Scenario: Smart mode skips non-URL columns
+    Given a WP install
+
+    When I run `wp search-replace --smart-url 'http://example.test' 'http://example.com' --dry-run --verbose`
+    Then STDOUT should contain:
+      """
+      Smart URL mode: Skipping
+      """
+    And STDOUT should contain:
+      """
+      columns:
+      """
+
+  @require-mysql
+  Scenario: Non-URL search does not trigger smart mode
+    Given a WP install
+
+    When I run `wp search-replace 'foo' 'bar' --dry-run`
+    Then STDOUT should not contain:
+      """
+      Smart URL mode
+      """
+    And STDOUT should not contain:
+      """
+      Detected URL replacement
+      """
+
+  @require-mysql
+  Scenario: URL replacement in post content
+    Given a WP install
+
+    When I run `wp post create --post_title="Test Post" --post_content="Visit http://oldsite.test for more info" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace --smart-url 'http://oldsite.test' 'http://newsite.com'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp post get {POST_ID} --field=post_content`
+    Then STDOUT should contain:
+      """
+      http://newsite.com
+      """
+    And STDOUT should not contain:
+      """
+      http://oldsite.test
+      """
+
+  @require-mysql
+  Scenario: URL replacement with skip-columns
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --post_content="http://example.test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace --smart-url 'http://example.test' 'http://example.com' --skip-columns=guid --dry-run`
+    Then STDOUT should not contain:
+      """
+      | wp_posts | guid |
+      """
+
+  @require-mysql
+  Scenario: URL replacement with include-columns
+    Given a WP install
+
+    When I run `wp search-replace --smart-url 'http://example.test' 'http://example.com' --include-columns=post_content --dry-run`
+    Then STDOUT should be a table containing rows:
+      | Table    | Column       | Replacements | Type |
+      | wp_posts | post_content | 0            | SQL  |
+
+  @require-mysql
+  Scenario: Multisite URL replacement
+    Given a WP multisite install
+    And I run `wp site create --slug="foo" --title="foo" --email="foo@example.com"`
+
+    When I run `wp search-replace --smart-url 'http://example.test' 'http://example.com' --network --dry-run`
+    Then STDOUT should contain:
+      """
+      wp_blogs
+      """
+
+  @require-mysql
+  Scenario: URL replacement with export
+    Given a WP install
+    And an empty cache
+
+    When I run `wp post create --post_title="Test" --post_content="http://oldurl.test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace --smart-url 'http://oldurl.test' 'http://newurl.com' --export`
+    Then STDOUT should contain:
+      """
+      INSERT INTO
+      """
+    And STDOUT should contain:
+      """
+      http://newurl.com
+      """
+
+  @require-mysql
+  Scenario: URL replacement in options table
+    Given a WP install
+
+    When I run `wp option add test_url 'http://testsite.test/page' --autoload=no`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp search-replace --smart-url 'http://testsite.test' 'http://testsite.com'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp option get test_url`
+    Then STDOUT should be:
+      """
+      http://testsite.com/page
+      """
+
+  @require-mysql
+  Scenario: URL replacement in post meta
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp post meta add {POST_ID} custom_url 'http://meta.test/path'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp search-replace --smart-url 'http://meta.test' 'http://meta.com'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp post meta get {POST_ID} custom_url`
+    Then STDOUT should be:
+      """
+      http://meta.com/path
+      """
+
+  @require-mysql
+  Scenario: URL replacement in comments
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp comment create --comment_post_ID={POST_ID} --comment_content="Check http://comment.test" --comment_author="Test" --comment_author_email="test@test.com" --porcelain`
+    Then save STDOUT as {COMMENT_ID}
+
+    When I run `wp search-replace --smart-url 'http://comment.test' 'http://comment.com'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp comment get {COMMENT_ID} --field=comment_content`
+    Then STDOUT should contain:
+      """
+      http://comment.com
+      """
+
+  @require-mysql
+  Scenario: Dry run does not modify database
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --post_content="http://dryrun.test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace --smart-url 'http://dryrun.test' 'http://dryrun.com' --dry-run`
+    Then STDOUT should match /replacement(s)? to be made/
+
+    When I run `wp post get {POST_ID} --field=post_content`
+    Then STDOUT should contain:
+      """
+      http://dryrun.test
+      """
+
+  @require-mysql
+  Scenario: Report changed only
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --post_content="http://report.test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace --smart-url 'http://report.test' 'http://report.com' --report-changed-only --dry-run`
+    Then STDOUT should contain:
+      """
+      post_content
+      """
+    And STDOUT should not contain:
+      """
+      | wp_posts | post_type | 0 |
+      """
+
+  @require-mysql
+  Scenario: Skip tables option
+    Given a WP install
+
+    When I run `wp search-replace --smart-url 'http://example.test' 'http://example.com' --skip-tables=wp_posts --dry-run`
+    Then STDOUT should not contain:
+      """
+      wp_posts
+      """
+    And STDOUT should contain:
+      """
+      wp_options
+      """
+
+  @require-mysql
+  Scenario: Specific tables only
+    Given a WP install
+
+    When I run `wp search-replace --smart-url 'http://example.test' 'http://example.com' wp_posts --dry-run`
+    Then STDOUT should contain:
+      """
+      wp_posts
+      """
+    And STDOUT should not contain:
+      """
+      wp_options
+      """
+
+  @require-mysql
+  Scenario: HTTP to HTTPS conversion
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --post_content="Visit http://secure.test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace --smart-url 'http://secure.test' 'https://secure.test'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp post get {POST_ID} --field=post_content`
+    Then STDOUT should contain:
+      """
+      https://secure.test
+      """
+
+  @require-mysql
+  Scenario: Advanced table analysis mode
+    Given a WP install
+
+    When I run `wp search-replace --smart-url 'http://example.test' 'http://example.com' --analyze-tables --dry-run --verbose`
+    Then STDOUT should contain:
+      """
+      Analyzing table structures
+      """
+    And STDOUT should contain:
+      """
+      Smart URL mode with table analysis
+      """
+
+  @require-mysql
+  Scenario: Table analysis skips integer columns
+    Given a WP install
+    And I run `wp db query "CREATE TABLE wp_test_table (id INT PRIMARY KEY, name VARCHAR(255), count BIGINT, url TEXT)"`
+
+    When I run `wp db query "INSERT INTO wp_test_table VALUES (1, 'test', 100, 'http://test.url')"`
+    Then STDERR should be empty
+
+    When I run `wp search-replace --smart-url 'http://test.url' 'http://new.url' wp_test_table --analyze-tables --all-tables-with-prefix`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp db query "SELECT url FROM wp_test_table WHERE id = 1" --skip-column-names`
+    Then STDOUT should contain:
+      """
+      http://new.url
+      """
+
+    When I run `wp db query "DROP TABLE wp_test_table"`
+    Then STDERR should be empty
+
+  @require-mysql
+  Scenario: Table analysis skips enum columns
+    Given a WP install
+    And I run `wp db query "CREATE TABLE wp_test_enum (id INT PRIMARY KEY, status ENUM('active','inactive'), data TEXT)"`
+
+    When I run `wp db query "INSERT INTO wp_test_enum VALUES (1, 'active', 'http://enum.test')"`
+    Then STDERR should be empty
+
+    When I run `wp search-replace --smart-url 'http://enum.test' 'http://enum.com' wp_test_enum --analyze-tables --all-tables-with-prefix`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp db query "SELECT data FROM wp_test_enum WHERE id = 1" --skip-column-names`
+    Then STDOUT should contain:
+      """
+      http://enum.com
+      """
+
+    When I run `wp db query "DROP TABLE wp_test_enum"`
+    Then STDERR should be empty
+
+  @require-mysql
+  Scenario: Table analysis skips date columns
+    Given a WP install
+    And I run `wp db query "CREATE TABLE wp_test_dates (id INT PRIMARY KEY, created_date DATE, url VARCHAR(255))"`
+
+    When I run `wp db query "INSERT INTO wp_test_dates VALUES (1, '2024-01-01', 'http://date.test')"`
+    Then STDERR should be empty
+
+    When I run `wp search-replace --smart-url 'http://date.test' 'http://date.com' wp_test_dates --analyze-tables --all-tables-with-prefix`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp db query "SELECT url FROM wp_test_dates WHERE id = 1" --skip-column-names`
+    Then STDOUT should contain:
+      """
+      http://date.com
+      """
+
+    When I run `wp db query "DROP TABLE wp_test_dates"`
+    Then STDERR should be empty
+
+  @require-mysql
+  Scenario: Table analysis with pattern matching
+    Given a WP install
+    And I run `wp db query "CREATE TABLE wp_test_patterns (order_id INT PRIMARY KEY, order_count INT, order_status VARCHAR(20), order_url TEXT)"`
+
+    When I run `wp db query "INSERT INTO wp_test_patterns VALUES (1, 5, 'pending', 'http://pattern.test')"`
+    Then STDERR should be empty
+
+    When I run `wp search-replace --smart-url 'http://pattern.test' 'http://pattern.com' wp_test_patterns --analyze-tables --all-tables-with-prefix --verbose`
+    Then STDOUT should contain:
+      """
+      Analyzing table structures
+      """
+
+    When I run `wp db query "SELECT order_url FROM wp_test_patterns WHERE order_id = 1" --skip-column-names`
+    Then STDOUT should contain:
+      """
+      http://pattern.com
+      """
+
+    When I run `wp db query "DROP TABLE wp_test_patterns"`
+    Then STDERR should be empty
+
+  @require-mysql
+  Scenario: Serialized data handling
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp post meta add {POST_ID} serialized_data 'a:2:{s:3:"url";s:18:"http://serial.test";s:4:"name";s:4:"test";}'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp db query "SELECT meta_value FROM wp_postmeta WHERE meta_key = 'serialized_data' AND post_id = {POST_ID}" --skip-column-names`
+    Then STDOUT should contain:
+      """
+      http://serial.test
+      """
+
+    When I run `wp search-replace --smart-url 'http://serial.test' 'http://serial.com'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp db query "SELECT meta_value FROM wp_postmeta WHERE meta_key = 'serialized_data' AND post_id = {POST_ID}" --skip-column-names`
+    Then STDOUT should contain:
+      """
+      http://serial.com
+      """
+
+  @require-mysql
+  Scenario: Large content replacement
+    Given a WP install
+
+    When I run `wp post create --post_title="Large Post" --post_content="$(printf 'http://large.test %.0s' {1..1000})" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace --smart-url 'http://large.test' 'http://large.com'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp post get {POST_ID} --field=post_content`
+    Then STDOUT should contain:
+      """
+      http://large.com
+      """
+    And STDOUT should not contain:
+      """
+      http://large.test
+      """
+
+  @require-mysql
+  Scenario: Multiple URL replacements in same content
+    Given a WP install
+
+    When I run `wp post create --post_title="Multi URL" --post_content="Visit http://multi.test and also http://multi.test/page" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace --smart-url 'http://multi.test' 'http://multi.com'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp post get {POST_ID} --field=post_content`
+    Then STDOUT should contain:
+      """
+      http://multi.com
+      """
+    And STDOUT should contain:
+      """
+      http://multi.com/page
+      """
+
+  @require-mysql
+  Scenario: Verbose output shows progress
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --post_content="http://verbose.test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace --smart-url 'http://verbose.test' 'http://verbose.com' --verbose`
+    Then STDOUT should contain:
+      """
+      Checking:
+      """
+
+  @require-mysql
+  Scenario: Count format output
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --post_content="http://count.test http://count.test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace --smart-url 'http://count.test' 'http://count.com' --format=count`
+    Then STDOUT should be a number
+
+  @require-mysql
+  Scenario: All tables with prefix
+    Given a WP install
+
+    When I run `wp search-replace --smart-url 'http://example.test' 'http://example.com' --all-tables-with-prefix --dry-run`
+    Then STDOUT should contain:
+      """
+      wp_
+      """
+
+  @require-mysql
+  Scenario: Recurse objects option
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp post meta add {POST_ID} object_data '{"url":"http://object.test","nested":{"url":"http://object.test/nested"}}'`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp search-replace --smart-url 'http://object.test' 'http://object.com' --recurse-objects`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+  @require-mysql
+  Scenario: Auto-detect http:// URL and enable smart mode
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --post_content="Visit http://autodetect.test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace 'http://autodetect.test' 'http://autodetect.com' --dry-run`
+    Then STDOUT should contain:
+      """
+      Detected URL replacement
+      """
+    And STDOUT should contain:
+      """
+      Automatically enabling smart-url mode
+      """
+
+  @require-mysql
+  Scenario: Auto-detect https:// URL and enable smart mode
+    Given a WP install
+
+    When I run `wp post create --post_title="Test" --post_content="Visit https://secure.test" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace 'https://secure.test' 'https://secure.com'`
+    Then STDOUT should contain:
+      """
+      Detected URL replacement
+      """
+    And STDOUT should contain:
+      """
+      Made
+      """
+
+  @require-mysql
+  Scenario: Auto-detect shows skipped columns in verbose mode
+    Given a WP install
+
+    When I run `wp search-replace 'http://verbose.test' 'http://verbose.com' --dry-run --verbose`
+    Then STDOUT should contain:
+      """
+      Detected URL replacement
+      """
+    And STDOUT should contain:
+      """
+      Smart URL mode: Skipping
+      """
+    And STDOUT should contain:
+      """
+      columns:
+      """
+
+  @require-mysql
+  Scenario: Regex mode disables auto-detection
+    Given a WP install
+
+    When I run `wp search-replace 'http://regex\.test' 'http://regex.com' --regex --dry-run`
+    Then STDOUT should not contain:
+      """
+      Detected URL replacement
+      """
+    And STDOUT should not contain:
+      """
+      Smart URL mode
+      """
+
+  @require-mysql
+  Scenario: Explicit --smart-url flag still works
+    Given a WP install
+
+    When I run `wp search-replace 'http://explicit.test' 'http://explicit.com' --smart-url --dry-run`
+    Then STDOUT should not contain:
+      """
+      Detected URL replacement
+      """
+    And STDOUT should contain:
+      """
+      replacements to be made
+      """
+
+  @require-mysql
+  Scenario: Auto-detection with actual URL replacement
+    Given a WP install
+
+    When I run `wp post create --post_title="Auto Test" --post_content="Check http://replace.test for info" --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp search-replace 'http://replace.test' 'http://replace.com'`
+    Then STDOUT should contain:
+      """
+      Detected URL replacement
+      """
+
+    When I run `wp post get {POST_ID} --field=post_content`
+    Then STDOUT should contain:
+      """
+      http://replace.com
+      """
+    And STDOUT should not contain:
+      """
+      http://replace.test
+      """
+
+  @require-mysql
+  Scenario: Error when --smart-url used with non-URL string
+    Given a WP install
+
+    When I try `wp search-replace --smart-url 'foo' 'bar'`
+    Then STDERR should contain:
+      """
+      Error: The --smart-url flag is designed for URL replacements, but "foo" is not a valid URL.
+      """
+    And the return code should be 1
+
+  @require-mysql
+  Scenario: Error when auto-detection would enable smart-url for invalid URL format
+    Given a WP install
+
+    When I try `wp search-replace 'http://invalid url with spaces' 'http://valid.com'`
+    Then STDERR should contain:
+      """
+      Error: The --smart-url flag is designed for URL replacements, but "http://invalid url with spaces" is not a valid URL.
+      """
+    And the return code should be 1
+

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -307,15 +307,20 @@ Feature: Do global search/replace
     And I run `wp post generate --count=20`
 
     When I run `wp search-replace <flags> {SITEURL} <replacement>`
-    Then STDOUT should be a table containing rows:
-      | Table    | Column | Replacements | Type |
-      | wp_posts | guid   | 20           | SQL  |
+    Then STDOUT should contain:
+      """
+      Detected URL replacement
+      """
+    And STDOUT should contain:
+      """
+      wp_posts	guid	20	SQL
+      """
 
     Examples:
-      | replacement           | flags     |
-      | {SITEURL}/subdir      |           |
-      | https://newdomain.com |           |
-      | https://newdomain.com | --dry-run |
+      | replacement       | flags     |
+      | {SITEURL}/subdir  |           |
+      | newdomain.com     |           |
+      | newdomain.com     | --dry-run |
 
   @require-mysql
   Scenario Outline: Choose replacement method (PHP or MySQL/MariaDB) given proper flags or data.
@@ -324,10 +329,14 @@ Feature: Do global search/replace
     And save STDOUT as {SITEURL}
     When I run `wp search-replace <flags> {SITEURL} https://wordpress.org`
 
-    Then STDOUT should be a table containing rows:
-      | Table      | Column       | Replacements | Type       |
-      | wp_options | option_value | 2            | <serial>   |
-      | wp_posts   | post_title   | 0            | <noserial> |
+    Then STDOUT should contain:
+      """
+      Detected URL replacement
+      """
+    And STDOUT should contain:
+      """
+      wp_options	option_value	2	<serial>
+      """
 
     Examples:
       | flags     | serial | noserial |
@@ -399,9 +408,14 @@ Feature: Do global search/replace
       """
 
     When I run `wp search-replace 'https://example.jp/' 'https://example.com/' wp_options --regex-delimiter='/'`
-    Then STDOUT should be a table containing rows:
-      | Table      | Column       | Replacements | Type |
-      | wp_options | option_value | 2            | PHP  |
+    Then STDOUT should contain:
+      """
+      Detected URL replacement
+      """
+    And STDOUT should contain:
+      """
+      wp_options	option_value	2	PHP
+      """
 
     When I run `wp option get home`
     Then STDOUT should be:

--- a/src/Search_Replace_Command.php
+++ b/src/Search_Replace_Command.php
@@ -1287,7 +1287,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 			);
 
 			if ( empty( $columns ) ) {
-				continue;
+				continue; // @codeCoverageIgnore
 			}
 
 			foreach ( $columns as $col ) {

--- a/src/WP_CLI/SearchReplace/Non_URL_Columns.php
+++ b/src/WP_CLI/SearchReplace/Non_URL_Columns.php
@@ -100,6 +100,9 @@ class Non_URL_Columns {
 			'comment_status',
 			'ping_status',
 			'post_password',
+			// Note: post_name is a slug (not a full URL) in normal WordPress usage.
+			// In rare edge cases (e.g. imports) it may contain URL-like strings, but we
+			// still treat it as non-URL for search/replace to keep this optimization simple.
 			'post_name',
 			'to_ping',
 			'pinged',

--- a/src/WP_CLI/SearchReplace/Non_URL_Columns.php
+++ b/src/WP_CLI/SearchReplace/Non_URL_Columns.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Non-URL column detection for search-replace operations.
+ *
+ * This class provides both a static list of WordPress core columns that never
+ * contain URLs, and dynamic analysis methods to detect non-URL columns based on
+ * MySQL datatypes (integers, dates, enums, blobs, etc.) and common naming patterns
+ * (*_id, *_count, *_status, is_*, has_*, etc.). Used by --smart-url and --analyze-tables.
+ *
+ * @package wp-cli/search-replace-command
+ */
+
+namespace WP_CLI\SearchReplace;
+
+/**
+ * Provides column skip lists for URL-specific search-replace operations.
+ */
+class Non_URL_Columns {
+
+	/**
+	 * MySQL column DATA_TYPE values that cannot safely/meaningfully contain URLs.
+	 *
+	 * Note: While binary columns technically could contain URL bytes, they are
+	 * commonly used for non-text data (compressed/encrypted/binary) and should
+	 * not be modified by string replacements.
+	 */
+	private const NON_TEXT_DATA_TYPES = array(
+		// Numeric types.
+		'tinyint',
+		'smallint',
+		'mediumint',
+		'int',
+		'bigint',
+		'decimal',
+		'numeric',
+		'float',
+		'double',
+		'real',
+		'bit',
+		'boolean',
+		'serial',
+
+		// Date/time types.
+		'date',
+		'datetime',
+		'timestamp',
+		'time',
+		'year',
+
+		// Binary types.
+		'binary',
+		'varbinary',
+		'tinyblob',
+		'blob',
+		'mediumblob',
+		'longblob',
+	);
+
+	/**
+	 * Regex patterns indicating a column name is unlikely to contain URLs.
+	 */
+	private const NON_URL_COLUMN_NAME_PATTERNS = array(
+		'/^.*_id$/i',        // Ends with _id (user_id, post_id, order_id)
+		'/^.*_count$/i',     // Ends with _count (view_count, item_count)
+		'/^.*_status$/i',    // Ends with _status (payment_status, order_status)
+		'/^.*_type$/i',      // Ends with _type (content_type, media_type)
+		'/^.*_date$/i',      // Ends with _date (created_date, modified_date)
+		'/^.*_time$/i',      // Ends with _time (start_time, end_time)
+		'/^.*_flag$/i',      // Ends with _flag (active_flag, deleted_flag)
+		'/^.*_number$/i',    // Ends with _number (order_number, invoice_number)
+		'/^.*_amount$/i',    // Ends with _amount (total_amount, tax_amount)
+		'/^.*_price$/i',     // Ends with _price (unit_price, sale_price)
+		'/^.*_quantity$/i',  // Ends with _quantity (stock_quantity)
+		'/^.*_rating$/i',    // Ends with _rating (average_rating)
+		'/^.*_order$/i',     // Ends with _order (sort_order, display_order)
+		'/^.*_index$/i',     // Ends with _index (sort_index)
+		'/^.*_position$/i',  // Ends with _position (menu_position)
+		'/^is_/i',           // Starts with is_ (is_active, is_deleted)
+		'/^has_/i',          // Starts with has_ (has_children, has_thumbnail)
+		'/^can_/i',          // Starts with can_ (can_edit, can_delete)
+		'/^total_/i',        // Starts with total_ (total_sales, total_views)
+		'/^num_/i',          // Starts with num_ (num_items, num_comments)
+		'/^max_/i',          // Starts with max_ (max_length, max_size)
+		'/^min_/i',          // Starts with min_ (min_length, min_size)
+	);
+
+	/**
+	 * Get the list of columns that never contain URLs in WordPress core tables.
+	 *
+	 * @return string[] List of column names to skip.
+	 */
+	public static function get_core_columns() {
+		return array(
+			// wp_posts table - Status, type, and metadata columns
+			'ID',
+			'post_author',
+			'post_date',
+			'post_date_gmt',
+			'post_status',
+			'comment_status',
+			'ping_status',
+			'post_password',
+			'post_name',
+			'to_ping',
+			'pinged',
+			'post_modified',
+			'post_modified_gmt',
+			'post_parent',
+			'menu_order',
+			'post_type',
+			'post_mime_type',
+			'comment_count',
+
+			// wp_postmeta table
+			'meta_id',
+			'post_id',
+
+			// wp_comments table - IDs, status, type, and dates
+			'comment_ID',
+			'comment_post_ID',
+			'comment_date',
+			'comment_date_gmt',
+			'comment_karma',
+			'comment_approved',
+			'comment_type',
+			'comment_parent',
+			'user_id',
+
+			// wp_commentmeta table
+			'comment_id',
+
+			// wp_users table - User metadata and status
+			'user_login',
+			'user_pass',
+			'user_nicename',
+			'user_email',
+			'user_registered',
+			'user_status',
+			'display_name',
+
+			// wp_usermeta table
+			'umeta_id',
+
+			// wp_terms table
+			'term_id',
+			'slug',
+			'term_group',
+
+			// wp_term_taxonomy table
+			'term_taxonomy_id',
+			'taxonomy',
+			'parent',
+			'count',
+
+			// wp_term_relationships table
+			'object_id',
+			'term_order',
+
+			// wp_options table
+			'option_id',
+			'autoload',
+
+			// wp_links table
+			'link_id',
+			'link_visible',
+			'link_owner',
+			'link_rating',
+			'link_updated',
+			'link_rel',
+			'link_rss',
+
+			// wp_blogs table (multisite)
+			'blog_id',
+			'site_id',
+			'registered',
+			'last_updated',
+			'public',
+			'archived',
+			'mature',
+			'spam',
+			'deleted',
+			'lang_id',
+
+			// wp_registration_log table (multisite)
+			'IP',
+			'email',
+			'date_registered',
+
+			// wp_signups table (multisite)
+			'signup_id',
+			'activated',
+			'active',
+		);
+	}
+
+	/**
+	 * Check if a column datatype cannot contain URLs (or is unsafe to modify).
+	 *
+	 * @param string $data_type   MySQL DATA_TYPE (e.g., 'int', 'varchar').
+	 * @param string $column_type Full COLUMN_TYPE (e.g., 'int(11)', 'enum(...)').
+	 * @return bool True if the datatype cannot contain URLs.
+	 */
+	public static function is_non_text_datatype( $data_type, $column_type ) {
+		$data_type_lc   = strtolower( $data_type );
+		$column_type_lc = strtolower( $column_type );
+
+		// Enum and set types (typically status/flag fields).
+		if ( 0 === strpos( $column_type_lc, 'enum(' ) ) {
+			return true;
+		}
+
+		if ( 0 === strpos( $column_type_lc, 'set(' ) ) {
+			return true;
+		}
+
+		return in_array( $data_type_lc, self::NON_TEXT_DATA_TYPES, true );
+	}
+
+	/**
+	 * Check if a column name matches patterns that indicate it cannot contain URLs.
+	 *
+	 * @param string $column_name The column name to check.
+	 * @return bool True if the column name matches a non-URL pattern.
+	 */
+	public static function matches_non_url_pattern( $column_name ) {
+		foreach ( self::NON_URL_COLUMN_NAME_PATTERNS as $pattern ) {
+			if ( preg_match( $pattern, $column_name ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
# Why
When search-replace-command for WP CLI scans for URLs and other bits of text to replace, it searches the whole SQL database for that value. Even tables in the WP core ecosystem that will never have a URL, columns like:

- `post_status` on `wp_posts`
- `meta_key` on `wp_postmeta`

While not a big deal for most WordPress sites, this becomes a persistent speed bump to cloning environments when you start dealing with databases with a large amount of rows or databases with multisite setups with a huge amount of tables.

# What this does 
What this change does is add two parameters to alleviate this pain that a WP-CLI user can call.

`--smart-url` - skip columns automactically that exist in WP Core that will NEVER have a URL as a value. These columns are statically fixed and exist in `src/WP_CLI/SearchReplace/Non_URL_Columns.php`.

`--analyze-tables` - can only be executed if `--smart-url` is also present in parameters. This parameter will tell WP-CLI to scan the database for columns that are non text datatypes in SQL (`binary`, `datetime`, etc.) and for column names that match the core WP pattern that would also not have a URL in it (`*_order`, `*_quantity`, etc.) that will be skipped additionally before search-replace runs. Will be a bit slower, but will capture more columns to skip for custom WP DB setups.

You must opt into these performance skips via the parameters above and it is only recommended that you do so if you are replacing URLs in the WP DB.

# Performance Gains
I've tested this in multiple local setups. In smaller setups (less than 1-2gb DB size) there was no noticeable difference between the scan speeds. However when the DB grew larger in my benchmarks (10GB) where there were a large amount of rows in `wp_postmeta` and `wp_posts` there was an average 30-40% savings over a normal search-replace scan speed.

## Test Run

| Command | Time | Improvement |
|---------|------|-------------|
| `wp search-replace` (standard) | 144s | baseline |
| `wp search-replace --smart-url` | 84s | **41.6% faster** |

### Test Details

- Database: ~15.72GB, ~30238733 rows
- Hardware: Docker on arm64
- Test: Dry-run search-replace of 'http://oldsite.com' to 'http://newsite.com'

### Standard Command Output

```
Table	Column	Replacements	Type
wp_commentmeta	meta_key	0	SQL
wp_commentmeta	meta_value	0	SQL
wp_comments	comment_author	0	SQL
wp_comments	comment_author_email	0	SQL
wp_comments	comment_author_url	200000	SQL
wp_comments	comment_author_IP	0	SQL
wp_comments	comment_content	200000	SQL
wp_comments	comment_approved	0	SQL
wp_comments	comment_agent	0	SQL
wp_comments	comment_type	0	SQL
wp_links	link_url	0	SQL
wp_links	link_name	0	SQL
wp_links	link_image	0	SQL
wp_links	link_target	0	SQL
wp_links	link_description	0	SQL
wp_links	link_visible	0	SQL
wp_links	link_rel	0	SQL
wp_links	link_notes	0	SQL
wp_links	link_rss	0	SQL
wp_options	option_name	0	SQL
wp_options	option_value	50000	PHP
wp_options	autoload	0	SQL
wp_postmeta	meta_key	0	SQL
wp_postmeta	meta_value	30000000	SQL
wp_posts	post_content	950000	SQL
wp_posts	post_title	0	SQL
wp_posts	post_excerpt	950000	SQL
wp_posts	post_status	0	SQL
wp_posts	comment_status	0	SQL
wp_posts	ping_status	0	SQL
wp_posts	post_password	0	SQL
wp_posts	post_name	0	SQL
wp_posts	to_ping	0	SQL
wp_posts	pinged	0	SQL
wp_posts	post_content_filtered	0	SQL
wp_posts	guid	950000	SQL
wp_posts	post_type	0	SQL
wp_posts	post_mime_type	0	SQL
wp_term_taxonomy	taxonomy	0	SQL
wp_term_taxonomy	description	0	SQL
wp_termmeta	meta_key	0	SQL
wp_termmeta	meta_value	0	SQL
wp_terms	name	0	SQL
wp_terms	slug	0	SQL
wp_usermeta	meta_key	0	SQL
wp_usermeta	meta_value	0	PHP
wp_users	user_login	0	SQL
wp_users	user_nicename	0	SQL
wp_users	user_email	0	SQL
wp_users	user_url	0	SQL
wp_users	user_activation_key	0	SQL
wp_users	display_name	0	SQL
Success: 33300000 replacements to be made.

real	2m23.679s
user	0m0.820s
sys	0m0.661s
```

### Smart URL Mode Output

```
Table	Column	Replacements	Type
wp_commentmeta	meta_value	0	SQL
wp_comments	comment_author	0	SQL
wp_comments	comment_author_email	0	SQL
wp_comments	comment_author_url	200000	SQL
wp_comments	comment_author_IP	0	SQL
wp_comments	comment_content	200000	SQL
wp_comments	comment_agent	0	SQL
wp_links	link_url	0	SQL
wp_links	link_name	0	SQL
wp_links	link_image	0	SQL
wp_links	link_target	0	SQL
wp_links	link_description	0	SQL
wp_links	link_notes	0	SQL
wp_options	option_value	50000	PHP
wp_postmeta	meta_value	30000000	SQL
wp_posts	post_content	950000	SQL
wp_posts	post_title	0	SQL
wp_posts	post_excerpt	950000	SQL
wp_posts	post_content_filtered	0	SQL
wp_posts	guid	950000	SQL
wp_term_taxonomy	description	0	SQL
wp_termmeta	meta_value	0	SQL
wp_terms	name	0	SQL
wp_usermeta	meta_value	0	PHP
wp_users	user_url	0	SQL
wp_users	user_activation_key	0	SQL
Success: 33300000 replacements to be made.

real	1m23.315s
user	0m0.775s
sys	0m0.698s
```


